### PR TITLE
Refactor resources to use lazy SSH connection

### DIFF
--- a/examples/resources/dokku_app/resource.tf
+++ b/examples/resources/dokku_app/resource.tf
@@ -28,8 +28,6 @@ resource "dokku_app" "demo2" {
       mount_path = "/app/config"
       # copy local directory "./config" to host directory, that will be mounted as "/app/config"
       local_directory = "./config"
-
-      PORT = "5000"
     }
   }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,130 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
+
+	"github.com/blang/semver"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/melbahja/goph"
+	"golang.org/x/crypto/ssh"
+)
+
+// DokkuConfig holds SSH configuration for lazy connection creation
+type DokkuConfig struct {
+	Host             string
+	Port             uint
+	User             string
+	CertPath         string
+	SkipHostKeyCheck bool
+	HostKey          string
+	LogSshCommands   bool
+	UploadAppName    string
+	UploadSplitBytes int
+}
+
+// NewClient creates a new dokkuClient with SSH connection on-demand
+func (c *DokkuConfig) NewClient(ctx context.Context) (*dokkuclient.Client, error) {
+	tflog.Debug(ctx, "Creating SSH connection", map[string]any{"host": c.Host, "port": c.Port, "user": c.User})
+
+	// Get SSH authentication
+	sshAuth, err := goph.Key(c.CertPath, "")
+	if err != nil {
+		return nil, fmt.Errorf("unable to find cert for SSH: %w", err)
+	}
+
+	// Configure SSH connection
+	sshConfig := &goph.Config{
+		Auth:     sshAuth,
+		Addr:     c.Host,
+		Port:     c.Port,
+		User:     c.User,
+		Callback: verifyHost,
+	}
+
+	if c.SkipHostKeyCheck {
+		sshConfig.Callback = ssh.InsecureIgnoreHostKey()
+	} else if c.HostKey != "" {
+		_, _, publicKey, _, _, err := ssh.ParseKnownHosts([]byte(c.HostKey))
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse provided ssh_host_key: %w", err)
+		}
+		sshConfig.Callback = ssh.FixedHostKey(publicKey)
+	}
+
+	// Establish SSH connection
+	client, err := goph.NewConn(sshConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to establish SSH connection: %w", err)
+	}
+
+	// Create dokku client
+	dokkuClient := dokkuclient.New(client, c.LogSshCommands, c.UploadAppName, c.UploadSplitBytes)
+
+	// Validate Dokku version on first connection
+	rawVersion, version, err := dokkuClient.GetVersion(ctx)
+	if err != nil {
+		client.Close()
+		if err == dokkuclient.ErrInvalidUser {
+			return nil, err
+		}
+		return nil, fmt.Errorf("unable to get dokku version: %w", err)
+	}
+
+	testedVersions := ">=0.24.0 <= 0.34.7"
+	if version.String() != "" {
+		tflog.Debug(ctx, "host version", map[string]any{"version": version})
+
+		compat := semver.MustParseRange(testedVersions)
+		if !compat(version) {
+			tflog.Warn(ctx, fmt.Sprintf("This provider has not been tested against Dokku version %s. Tested version range: %s", rawVersion, testedVersions))
+		}
+	}
+
+	tflog.Debug(ctx, "SSH connection established successfully")
+	return dokkuClient, nil
+}
+
+// CloseClient closes the underlying SSH connection
+func (c *DokkuConfig) CloseClient(client *dokkuclient.Client) error {
+	if client != nil && client.GetSSHClient() != nil {
+		return client.GetSSHClient().Close()
+	}
+	return nil
+}
+
+func verifyHost(host string, remote net.Addr, key ssh.PublicKey) error {
+	// If you want to connect to new hosts.
+	// here your should check new connections public keys
+	// if the key not trusted you shuld return an error
+
+	// hostFound: is host in known hosts file.
+	// err: error if key not in known hosts file OR host in known hosts file but key changed!
+	hostFound, err := goph.CheckKnownHost(host, remote, key, "")
+
+	// Host in known hosts but key mismatch!
+	// Maybe because of MAN IN THE MIDDLE ATTACK!
+	if hostFound && err != nil {
+
+		return err
+	}
+
+	// handshake because public key already exists.
+	if hostFound && err == nil {
+
+		return nil
+	}
+
+	// // Ask user to check if he trust the host public key.
+	// if askIsHostTrusted(host, key) == false {
+
+	// 	// Make sure to return error on non trusted keys.
+	// 	return errors.New("you typed no, aborted!")
+	// }
+
+	// Add the new host to known hosts file.
+	return goph.AddKnownHost(host, remote, key, "")
+}

--- a/provider/app_resource.go
+++ b/provider/app_resource.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
@@ -35,7 +36,7 @@ func NewAppResource() resource.Resource {
 }
 
 type appResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type appResourceModel struct {
@@ -92,14 +93,22 @@ func (r *appResource) Metadata(_ context.Context, req resource.MetadataRequest, 
 	resp.TypeName = req.ProviderTypeName + "_app"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *appResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *appResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -388,8 +397,16 @@ func (r *appResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check app existence
-	exists, err := r.client.AppExists(ctx, state.AppName.ValueString())
+	exists, err := client.AppExists(ctx, state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("app_name"), "Unable to check app existence", "Unable to check app existence. "+err.Error())
 		return
@@ -399,7 +416,7 @@ func (r *appResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return
 	}
 
-	config, err := r.client.ConfigExport(ctx, state.AppName.ValueString())
+	config, err := client.ConfigExport(ctx, state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("config"), "Unable to get config", "Unable to get config. "+err.Error())
 	} else {
@@ -442,7 +459,7 @@ func (r *appResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		}
 	}
 
-	storage, err := r.client.StorageExport(ctx, state.AppName.ValueString())
+	storage, err := client.StorageExport(ctx, state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("storage"), "Unable to get storage", "Unable to get storage. "+err.Error())
 	} else {
@@ -465,7 +482,7 @@ func (r *appResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		}
 	}
 
-	checkStatus, err := r.client.ChecksGet(ctx, state.AppName.ValueString())
+	checkStatus, err := client.ChecksGet(ctx, state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("checks"), "Unable to get checks", "Unable to get checks. "+err.Error())
 	} else {
@@ -478,7 +495,7 @@ func (r *appResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		}
 	}
 
-	domains, err := r.client.DomainsExport(ctx, state.AppName.ValueString())
+	domains, err := client.DomainsExport(ctx, state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("domains"), "Unable to get domains", "Unable to get domains. "+err.Error())
 	} else {
@@ -496,7 +513,7 @@ func (r *appResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		}
 	}
 
-	ports, err := r.client.PortsExport(ctx, state.AppName.ValueString())
+	ports, err := client.PortsExport(ctx, state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("ports"), "Unable to get ports", "Unable to get ports. "+err.Error())
 	} else {
@@ -536,7 +553,7 @@ func (r *appResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 
 	// dockerOptions -- unable to read because it can be set externally
 
-	networks, err := r.client.NetworksReport(ctx, state.AppName.ValueString())
+	networks, err := client.NetworksReport(ctx, state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("networks"), "Unable to get networks", "Unable to get networks. "+err.Error())
 	} else {
@@ -593,8 +610,16 @@ func (r *appResource) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check app existence
-	exists, err := r.client.AppExists(ctx, plan.AppName.ValueString())
+	exists, err := client.AppExists(ctx, plan.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("app_name"), "Unable to check app existence", "Unable to check app existence. "+err.Error())
 		return
@@ -605,7 +630,7 @@ func (r *appResource) Create(ctx context.Context, req resource.CreateRequest, re
 	}
 
 	// Create new app
-	err = r.client.AppCreate(ctx, plan.AppName.ValueString())
+	err = client.AppCreate(ctx, plan.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create app", "Unable to create app. "+err.Error())
 		// if not created - return to not try to destroy on other errors
@@ -620,19 +645,19 @@ func (r *appResource) Create(ctx context.Context, req resource.CreateRequest, re
 				config[k] = stringVal.ValueString()
 			}
 		}
-		err := r.client.ConfigSet(ctx, plan.AppName.ValueString(), config)
+		err := client.ConfigSet(ctx, plan.AppName.ValueString(), config)
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("config"), "Unable to set config", "Unable to set config. "+err.Error())
 		}
 	}
 
 	for hostPath, storage := range plan.Storage {
-		err := r.client.StorageEnsure(ctx, hostPath, storage.LocalDirectory.ValueStringPointer())
+		err := client.StorageEnsure(ctx, hostPath, storage.LocalDirectory.ValueStringPointer())
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("storage").AtMapKey(hostPath), "Unable to ensure storage", "Unable to ensure storage. "+err.Error())
 		}
 
-		err = r.client.StorageMount(ctx, plan.AppName.ValueString(), hostPath, storage.MountPath.ValueString())
+		err = client.StorageMount(ctx, plan.AppName.ValueString(), hostPath, storage.MountPath.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("storage").AtMapKey(hostPath), "Unable to mount storage", "Unable to mount storage. "+err.Error())
 		}
@@ -640,7 +665,7 @@ func (r *appResource) Create(ctx context.Context, req resource.CreateRequest, re
 
 	if plan.Checks != nil {
 		if !plan.Checks.Status.IsNull() {
-			err := r.client.ChecksSet(ctx, plan.AppName.ValueString(), plan.Checks.Status.ValueString())
+			err := client.ChecksSet(ctx, plan.AppName.ValueString(), plan.Checks.Status.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddAttributeError(path.Root("checks"), "Unable to set checks", "Unable to set checks. "+err.Error())
 			}
@@ -667,16 +692,16 @@ func (r *appResource) Create(ctx context.Context, req resource.CreateRequest, re
 				ContainerPort: port.ContainerPort.ValueString(),
 			})
 		}
-		err := r.client.PortsSet(ctx, plan.AppName.ValueString(), ports)
+		err := client.PortsSet(ctx, plan.AppName.ValueString(), ports)
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("ports"), "Unable to set ports", "Unable to set ports. "+err.Error())
 		}
-		err = r.client.ProxyEnable(ctx, plan.AppName.ValueString())
+		err = client.ProxyEnable(ctx, plan.AppName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("ports"), "Unable to enable ports", "Unable to enable ports. "+err.Error())
 		}
 	} else {
-		err = r.client.ProxyDisable(ctx, plan.AppName.ValueString())
+		err = client.ProxyDisable(ctx, plan.AppName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("ports"), "Unable to disable ports", "Unable to disable ports. "+err.Error())
 		}
@@ -690,23 +715,23 @@ func (r *appResource) Create(ctx context.Context, req resource.CreateRequest, re
 				domains = append(domains, stringVal.ValueString())
 			}
 		}
-		err := r.client.DomainsSet(ctx, plan.AppName.ValueString(), domains)
+		err := client.DomainsSet(ctx, plan.AppName.ValueString(), domains)
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("domains"), "Unable to add domain", "Unable to add domain. "+err.Error())
 		}
-		err = r.client.DomainsEnable(ctx, plan.AppName.ValueString())
+		err = client.DomainsEnable(ctx, plan.AppName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("domains"), "Unable to enable domains support", "Unable to enable domains support. "+err.Error())
 		}
 	} else {
-		err = r.client.DomainsDisable(ctx, plan.AppName.ValueString())
+		err = client.DomainsDisable(ctx, plan.AppName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("domains"), "Unable to disable domains support", "Unable to disable domains support. "+err.Error())
 		}
 	}
 
 	for option, dockerOption := range plan.DockerOptions {
-		err := r.client.DockerOptionAdd(ctx, plan.AppName.ValueString(), formatDockerOptionsPhases(dockerOption.Phase), option)
+		err := client.DockerOptionAdd(ctx, plan.AppName.ValueString(), formatDockerOptionsPhases(dockerOption.Phase), option)
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("docker_options").AtMapKey(option), "Unable to add docker option", "Unable to add docker option. "+err.Error())
 		}
@@ -714,19 +739,19 @@ func (r *appResource) Create(ctx context.Context, req resource.CreateRequest, re
 
 	if plan.Networks != nil {
 		if !plan.Networks.AttachPostCreate.IsNull() {
-			err := r.client.NetworkEnsureAndSetForApp(ctx, plan.AppName.ValueString(), "attach-post-create", plan.Networks.AttachPostCreate.ValueString())
+			err := client.NetworkEnsureAndSetForApp(ctx, plan.AppName.ValueString(), "attach-post-create", plan.Networks.AttachPostCreate.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddAttributeError(path.Root("networks").AtName("attach_post_create"), "Unable to set network", "Unable to set network. "+err.Error())
 			}
 		}
 		if !plan.Networks.AttachPostDeploy.IsNull() {
-			err := r.client.NetworkEnsureAndSetForApp(ctx, plan.AppName.ValueString(), "attach-post-deploy", plan.Networks.AttachPostDeploy.ValueString())
+			err := client.NetworkEnsureAndSetForApp(ctx, plan.AppName.ValueString(), "attach-post-deploy", plan.Networks.AttachPostDeploy.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddAttributeError(path.Root("networks").AtName("attach_post_deploy"), "Unable to set network", "Unable to set network. "+err.Error())
 			}
 		}
 		if !plan.Networks.InitialNetwork.IsNull() {
-			err := r.client.NetworkEnsureAndSetForApp(ctx, plan.AppName.ValueString(), "initial_network", plan.Networks.InitialNetwork.ValueString())
+			err := client.NetworkEnsureAndSetForApp(ctx, plan.AppName.ValueString(), "initial_network", plan.Networks.InitialNetwork.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddAttributeError(path.Root("networks").AtName("initial_network"), "Unable to set network", "Unable to set network. "+err.Error())
 			}
@@ -734,14 +759,14 @@ func (r *appResource) Create(ctx context.Context, req resource.CreateRequest, re
 	}
 
 	if plan.Deploy != nil && !resp.Diagnostics.HasError() {
-		_, err := r.deploy(ctx, plan.AppName.ValueString(), *plan.Deploy)
+		_, err := r.deploy(ctx, client, plan.AppName.ValueString(), *plan.Deploy)
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("deploy"), "Unable to deploy", "Unable to deploy. "+err.Error())
 		}
 	}
 
 	if resp.Diagnostics.HasError() {
-		err := r.client.AppDestroy(ctx, plan.AppName.ValueString())
+		err := client.AppDestroy(ctx, plan.AppName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to destroy app", "Unable to destroy app. "+err.Error())
 		}
@@ -777,6 +802,14 @@ func (r *appResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		return
 	}
 	appName := plan.AppName.ValueString()
+
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
 
 	restartRequired := false
 
@@ -818,7 +851,7 @@ func (r *appResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		}
 	}
 	if len(namesToUnset) != 0 {
-		err := r.client.ConfigUnset(ctx, appName, namesToUnset)
+		err := client.ConfigUnset(ctx, appName, namesToUnset)
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("config"), "Unable to unset config", "Unable to unset config. "+err.Error())
 		}
@@ -834,7 +867,7 @@ func (r *appResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		}
 	}
 	if len(configToSet) != 0 {
-		err := r.client.ConfigSet(ctx, appName, configToSet)
+		err := client.ConfigSet(ctx, appName, configToSet)
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("config"), "Unable to set config", "Unable to set config. "+err.Error())
 		}
@@ -850,24 +883,24 @@ func (r *appResource) Update(ctx context.Context, req resource.UpdateRequest, re
 				found = true
 
 				if !existingStorage.MountPath.Equal(planStorage.MountPath) {
-					err := r.client.StorageUnmount(ctx, appName, existingName, existingStorage.MountPath.ValueString())
+					err := client.StorageUnmount(ctx, appName, existingName, existingStorage.MountPath.ValueString())
 					if err != nil {
 						resp.Diagnostics.AddAttributeError(path.Root("storage").AtMapKey(existingName), "Unable to unmount storage", "Unable to unmount storage. "+err.Error())
 					}
 
-					err = r.client.StorageEnsure(ctx, planName, planStorage.LocalDirectory.ValueStringPointer())
+					err = client.StorageEnsure(ctx, planName, planStorage.LocalDirectory.ValueStringPointer())
 					if err != nil {
 						resp.Diagnostics.AddAttributeError(path.Root("storage").AtMapKey(existingName), "Unable to ensure storage", "Unable to ensure storage. "+err.Error())
 					}
 
-					err = r.client.StorageMount(ctx, appName, planName, planStorage.MountPath.ValueString())
+					err = client.StorageMount(ctx, appName, planName, planStorage.MountPath.ValueString())
 					if err != nil {
 						resp.Diagnostics.AddAttributeError(path.Root("storage").AtMapKey(existingName), "Unable to mount storage", "Unable to mount storage. "+err.Error())
 					}
 
 					restartRequired = true
 				} else if !planStorage.LocalDirectory.IsNull() {
-					err := r.client.StorageEnsure(ctx, planName, planStorage.LocalDirectory.ValueStringPointer())
+					err := client.StorageEnsure(ctx, planName, planStorage.LocalDirectory.ValueStringPointer())
 					if err != nil {
 						resp.Diagnostics.AddAttributeError(path.Root("storage").AtMapKey(existingName), "Unable to ensure storage", "Unable to ensure storage. "+err.Error())
 					}
@@ -879,7 +912,7 @@ func (r *appResource) Update(ctx context.Context, req resource.UpdateRequest, re
 			}
 		}
 		if !found {
-			err := r.client.StorageUnmount(ctx, appName, existingName, existingStorage.MountPath.ValueString())
+			err := client.StorageUnmount(ctx, appName, existingName, existingStorage.MountPath.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddAttributeError(path.Root("storage").AtMapKey(existingName), "Unable to unmount storage", "Unable to unmount storage. "+err.Error())
 			}
@@ -896,12 +929,12 @@ func (r *appResource) Update(ctx context.Context, req resource.UpdateRequest, re
 			}
 		}
 		if !found {
-			err := r.client.StorageEnsure(ctx, planName, planStorage.LocalDirectory.ValueStringPointer())
+			err := client.StorageEnsure(ctx, planName, planStorage.LocalDirectory.ValueStringPointer())
 			if err != nil {
 				resp.Diagnostics.AddAttributeError(path.Root("storage").AtMapKey(planName), "Unable to ensure storage", "Unable to ensure storage. "+err.Error())
 			}
 
-			err = r.client.StorageMount(ctx, appName, planName, planStorage.MountPath.ValueString())
+			err = client.StorageMount(ctx, appName, planName, planStorage.MountPath.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddAttributeError(path.Root("storage").AtMapKey(planName), "Unable to mount storage", "Unable to mount storage. "+err.Error())
 			}
@@ -921,7 +954,7 @@ func (r *appResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		planCheckStatus = plan.Checks.Status.ValueString()
 	}
 	if stateCheckStatus != planCheckStatus {
-		err := r.client.ChecksSet(ctx, appName, planCheckStatus)
+		err := client.ChecksSet(ctx, appName, planCheckStatus)
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("checks"), "Unable to set checks", "Unable to set checks. "+err.Error())
 		}
@@ -996,22 +1029,22 @@ func (r *appResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	}
 	if needToSetPorts {
 		if len(portsToSet) == 0 {
-			err := r.client.PortsClear(ctx, appName)
+			err := client.PortsClear(ctx, appName)
 			if err != nil {
 				resp.Diagnostics.AddAttributeError(path.Root("ports"), "Unable to clear ports", "Unable to clear ports. "+err.Error())
 			}
 
-			err = r.client.ProxyDisable(ctx, appName)
+			err = client.ProxyDisable(ctx, appName)
 			if err != nil {
 				resp.Diagnostics.AddAttributeError(path.Root("ports"), "Unable to disable ports", "Unable to disable ports. "+err.Error())
 			}
 		} else {
-			err := r.client.PortsSet(ctx, appName, portsToSet)
+			err := client.PortsSet(ctx, appName, portsToSet)
 			if err != nil {
 				resp.Diagnostics.AddAttributeError(path.Root("ports"), "Unable to set ports", "Unable to set ports. "+err.Error())
 			}
 
-			err = r.client.ProxyEnable(ctx, appName)
+			err = client.ProxyEnable(ctx, appName)
 			if err != nil {
 				resp.Diagnostics.AddAttributeError(path.Root("ports"), "Unable to enable ports", "Unable to enable ports. "+err.Error())
 			}
@@ -1074,22 +1107,22 @@ func (r *appResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	if needToSetDomains {
 		var err error
 		if len(domainsToSet) == 0 {
-			err = r.client.DomainsDisable(ctx, appName)
+			err = client.DomainsDisable(ctx, appName)
 			if err != nil {
 				resp.Diagnostics.AddAttributeError(path.Root("domains"), "Unable to disable domains support", "Unable to disable domains support. "+err.Error())
 			}
 
-			err = r.client.DomainsClear(ctx, appName)
+			err = client.DomainsClear(ctx, appName)
 			if err != nil {
 				resp.Diagnostics.AddAttributeError(path.Root("domains"), "Unable to clear domains", "Unable to clear domains. "+err.Error())
 			}
 		} else {
-			err = r.client.DomainsEnable(ctx, appName)
+			err = client.DomainsEnable(ctx, appName)
 			if err != nil {
 				resp.Diagnostics.AddAttributeError(path.Root("domains"), "Unable to enable domains support", "Unable to enable domains support. "+err.Error())
 			}
 
-			err = r.client.DomainsSet(ctx, appName, domainsToSet)
+			err = client.DomainsSet(ctx, appName, domainsToSet)
 			if err != nil {
 				resp.Diagnostics.AddAttributeError(path.Root("domains"), "Unable to set domains", "Unable to set domains. "+err.Error())
 			}
@@ -1106,12 +1139,12 @@ func (r *appResource) Update(ctx context.Context, req resource.UpdateRequest, re
 				found = true
 
 				if !existingDockerOption.Phase.Equal(planDockerOption.Phase) {
-					err := r.client.DockerOptionRemove(ctx, appName, formatDockerOptionsPhases(existingDockerOption.Phase), existingValue)
+					err := client.DockerOptionRemove(ctx, appName, formatDockerOptionsPhases(existingDockerOption.Phase), existingValue)
 					if err != nil {
 						resp.Diagnostics.AddAttributeError(path.Root("storage").AtMapKey(existingValue), "Unable to remove docker option", "Unable to remove docker option. "+err.Error())
 					}
 
-					err = r.client.DockerOptionAdd(ctx, appName, formatDockerOptionsPhases(planDockerOption.Phase), planValue)
+					err = client.DockerOptionAdd(ctx, appName, formatDockerOptionsPhases(planDockerOption.Phase), planValue)
 					if err != nil {
 						resp.Diagnostics.AddAttributeError(path.Root("storage").AtMapKey(existingValue), "Unable to add docker option", "Unable to add docker option. "+err.Error())
 					}
@@ -1123,7 +1156,7 @@ func (r *appResource) Update(ctx context.Context, req resource.UpdateRequest, re
 			}
 		}
 		if !found {
-			err := r.client.DockerOptionRemove(ctx, appName, formatDockerOptionsPhases(existingDockerOption.Phase), existingValue)
+			err := client.DockerOptionRemove(ctx, appName, formatDockerOptionsPhases(existingDockerOption.Phase), existingValue)
 			if err != nil {
 				resp.Diagnostics.AddAttributeError(path.Root("docker_options").AtMapKey(existingValue), "Unable to remove docker option", "Unable to remove docker option. "+err.Error())
 			}
@@ -1140,7 +1173,7 @@ func (r *appResource) Update(ctx context.Context, req resource.UpdateRequest, re
 			}
 		}
 		if !found {
-			err := r.client.DockerOptionAdd(ctx, appName, formatDockerOptionsPhases(planDockerOption.Phase), planValue)
+			err := client.DockerOptionAdd(ctx, appName, formatDockerOptionsPhases(planDockerOption.Phase), planValue)
 			if err != nil {
 				resp.Diagnostics.AddAttributeError(path.Root("docker_options").AtMapKey(planValue), "Unable to add docker option", "Unable to add docker option. "+err.Error())
 			}
@@ -1154,38 +1187,38 @@ func (r *appResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	if state.Networks != nil {
 		if plan.Networks != nil {
 			if !plan.Networks.AttachPostCreate.Equal(state.Networks.AttachPostCreate) {
-				err := r.client.NetworkEnsureAndSetForApp(ctx, appName, "attach-post-create", plan.Networks.AttachPostCreate.ValueString())
+				err := client.NetworkEnsureAndSetForApp(ctx, appName, "attach-post-create", plan.Networks.AttachPostCreate.ValueString())
 				if err != nil {
 					resp.Diagnostics.AddAttributeError(path.Root("networks").AtName("attach_post_create"), "Unable to set network", "Unable to set network. "+err.Error())
 				}
 			}
 			if !plan.Networks.AttachPostDeploy.Equal(state.Networks.AttachPostDeploy) {
-				err := r.client.NetworkEnsureAndSetForApp(ctx, appName, "attach-post-deploy", plan.Networks.AttachPostDeploy.ValueString())
+				err := client.NetworkEnsureAndSetForApp(ctx, appName, "attach-post-deploy", plan.Networks.AttachPostDeploy.ValueString())
 				if err != nil {
 					resp.Diagnostics.AddAttributeError(path.Root("networks").AtName("attach_post_deploy"), "Unable to set network", "Unable to set network. "+err.Error())
 				}
 			}
 			if !plan.Networks.InitialNetwork.Equal(state.Networks.InitialNetwork) {
-				err := r.client.NetworkEnsureAndSetForApp(ctx, appName, "initial-network", plan.Networks.InitialNetwork.ValueString())
+				err := client.NetworkEnsureAndSetForApp(ctx, appName, "initial-network", plan.Networks.InitialNetwork.ValueString())
 				if err != nil {
 					resp.Diagnostics.AddAttributeError(path.Root("networks").AtName("initial_network"), "Unable to set network", "Unable to set network. "+err.Error())
 				}
 			}
 		} else {
 			if !state.Networks.AttachPostCreate.IsNull() {
-				err := r.client.NetworkUnsetForApp(ctx, appName, "attach-post-create")
+				err := client.NetworkUnsetForApp(ctx, appName, "attach-post-create")
 				if err != nil {
 					resp.Diagnostics.AddAttributeError(path.Root("networks").AtName("attach_post_create"), "Unable to unset network", "Unable to unset network. "+err.Error())
 				}
 			}
 			if !state.Networks.AttachPostDeploy.IsNull() {
-				err := r.client.NetworkUnsetForApp(ctx, appName, "attach-post-deploy")
+				err := client.NetworkUnsetForApp(ctx, appName, "attach-post-deploy")
 				if err != nil {
 					resp.Diagnostics.AddAttributeError(path.Root("networks").AtName("attach_post_deploy"), "Unable to unset network", "Unable to unset network. "+err.Error())
 				}
 			}
 			if !state.Networks.InitialNetwork.IsNull() {
-				err := r.client.NetworkUnsetForApp(ctx, appName, "initial-network")
+				err := client.NetworkUnsetForApp(ctx, appName, "initial-network")
 				if err != nil {
 					resp.Diagnostics.AddAttributeError(path.Root("networks").AtName("initial_network"), "Unable to unset network", "Unable to unset network. "+err.Error())
 				}
@@ -1194,19 +1227,19 @@ func (r *appResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	} else {
 		if plan.Networks != nil {
 			if !plan.Networks.AttachPostCreate.IsNull() {
-				err := r.client.NetworkEnsureAndSetForApp(ctx, appName, "attach-post-create", plan.Networks.AttachPostCreate.ValueString())
+				err := client.NetworkEnsureAndSetForApp(ctx, appName, "attach-post-create", plan.Networks.AttachPostCreate.ValueString())
 				if err != nil {
 					resp.Diagnostics.AddAttributeError(path.Root("networks").AtName("attach_post_create"), "Unable to set network", "Unable to set network. "+err.Error())
 				}
 			}
 			if !plan.Networks.AttachPostDeploy.IsNull() {
-				err := r.client.NetworkEnsureAndSetForApp(ctx, appName, "attach-post-deploy", plan.Networks.AttachPostDeploy.ValueString())
+				err := client.NetworkEnsureAndSetForApp(ctx, appName, "attach-post-deploy", plan.Networks.AttachPostDeploy.ValueString())
 				if err != nil {
 					resp.Diagnostics.AddAttributeError(path.Root("networks").AtName("attach_post_deploy"), "Unable to set network", "Unable to set network. "+err.Error())
 				}
 			}
 			if !plan.Networks.InitialNetwork.IsNull() {
-				err := r.client.NetworkEnsureAndSetForApp(ctx, appName, "initial-network", plan.Networks.InitialNetwork.ValueString())
+				err := client.NetworkEnsureAndSetForApp(ctx, appName, "initial-network", plan.Networks.InitialNetwork.ValueString())
 				if err != nil {
 					resp.Diagnostics.AddAttributeError(path.Root("networks").AtName("initial_network"), "Unable to set network", "Unable to set network. "+err.Error())
 				}
@@ -1217,7 +1250,7 @@ func (r *appResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 	// -- deploy
 	if plan.Deploy != nil {
-		deployed, err := r.deploy(ctx, plan.AppName.ValueString(), *plan.Deploy)
+		deployed, err := r.deploy(ctx, client, plan.AppName.ValueString(), *plan.Deploy)
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(path.Root("deploy"), "Unable to deploy", "Unable to deploy. "+err.Error())
 		}
@@ -1228,7 +1261,7 @@ func (r *appResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	// --
 
 	if !resp.Diagnostics.HasError() && restartRequired {
-		err := r.client.ProcessRestart(ctx, appName)
+		err := client.ProcessRestart(ctx, appName)
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to restart process", "Unable to restart process. "+err.Error())
 		}
@@ -1254,7 +1287,15 @@ func (r *appResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		return
 	}
 
-	exists, err := r.client.AppExists(ctx, state.AppName.ValueString())
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
+	exists, err := client.AppExists(ctx, state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(path.Root("app_name"), "Unable to check app existence", "Unable to check app existence. "+err.Error())
 		return
@@ -1264,7 +1305,7 @@ func (r *appResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 	}
 
 	// Delete existing app
-	err = r.client.AppDestroy(ctx, state.AppName.ValueString())
+	err = client.AppDestroy(ctx, state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to destroy app", "Unable to destroy app. "+err.Error())
 		return
@@ -1276,10 +1317,10 @@ func (r *appResource) ImportState(ctx context.Context, req resource.ImportStateR
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("app_name"), req.ID)...)
 }
 
-func (r *appResource) deploy(ctx context.Context, appName string, deployModel deployModel) (deployed bool, err error) {
+func (r *appResource) deploy(ctx context.Context, client *dokkuclient.Client, appName string, deployModel deployModel) (deployed bool, err error) {
 	switch deployModel.Type.ValueString() {
 	case "archive":
-		err = r.client.DeployFromArchive(ctx, appName, deployModel.ArchiveType.ValueString(), deployModel.ArchiveUrl.ValueString())
+		err = client.DeployFromArchive(ctx, appName, deployModel.ArchiveType.ValueString(), deployModel.ArchiveUrl.ValueString())
 		deployed = err == nil
 	case "docker_image":
 		if !deployModel.Login.IsNull() && !deployModel.Password.IsNull() {
@@ -1287,26 +1328,26 @@ func (r *appResource) deploy(ctx context.Context, appName string, deployModel de
 			if err != nil {
 				return false, fmt.Errorf("unable to parse url: %w", err)
 			}
-			err = r.client.RegistryLogin(ctx, u.Host, deployModel.Login.ValueString(), deployModel.Password.ValueString())
+			err = client.RegistryLogin(ctx, u.Host, deployModel.Login.ValueString(), deployModel.Password.ValueString())
 			if err != nil {
 				return false, fmt.Errorf("unable to login to registry: %w", err)
 			}
 		}
 
-		deployed, err = r.client.DeployFromImage(ctx, appName, deployModel.DockerImage.ValueString(), deployModel.AllowRebuild.ValueBool())
+		deployed, err = client.DeployFromImage(ctx, appName, deployModel.DockerImage.ValueString(), deployModel.AllowRebuild.ValueBool())
 	case "git_repository":
 		if !deployModel.Login.IsNull() && !deployModel.Password.IsNull() {
 			u, err := url.Parse(deployModel.GitRepository.ValueString())
 			if err != nil {
 				return false, fmt.Errorf("unable to parse url: %w", err)
 			}
-			err = r.client.GitAuth(ctx, u.Host, deployModel.Login.ValueString(), deployModel.Password.ValueString())
+			err = client.GitAuth(ctx, u.Host, deployModel.Login.ValueString(), deployModel.Password.ValueString())
 			if err != nil {
 				return false, fmt.Errorf("unable to login to git: %w", err)
 			}
 		}
 
-		err = r.client.DeploySyncRepository(ctx, appName, deployModel.GitRepository.ValueString(), deployModel.GitRepositoryRef.ValueString())
+		err = client.DeploySyncRepository(ctx, appName, deployModel.GitRepository.ValueString(), deployModel.GitRepositoryRef.ValueString())
 		deployed = err == nil
 	default:
 		err = fmt.Errorf("Unknown deploy type %s", deployModel.Type.ValueString())

--- a/provider/dokku_client/client.go
+++ b/provider/dokku_client/client.go
@@ -132,3 +132,8 @@ func (c *Client) GetVersion(ctx context.Context) (rawVersion string, parsedVersi
 	c.dokkuVersion = parsedVersion
 	return found, parsedVersion, err
 }
+
+// GetSSHClient returns the underlying SSH client for connection management
+func (c *Client) GetSSHClient() *goph.Client {
+	return c.client
+}

--- a/provider/dokku_client/storage.go
+++ b/provider/dokku_client/storage.go
@@ -32,7 +32,13 @@ func (c *Client) StorageExport(ctx context.Context, appName string) (res map[str
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
+		if !strings.Contains(line, ":") {
+			continue
+		}
 		parts := strings.Split(line, ":")
+		if len(parts) < 2 {
+			continue
+		}
 		hostpath := strings.TrimSpace(parts[0])
 		if len(hostpath) > len(hostStoragePrefix) && hostpath[:len(hostStoragePrefix)] == hostStoragePrefix {
 			res[hostpath[len(hostStoragePrefix):]] = parts[1]

--- a/provider/domain_resource.go
+++ b/provider/domain_resource.go
@@ -2,10 +2,10 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
-	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
-
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -27,7 +27,7 @@ func NewDomainResource() resource.Resource {
 }
 
 type domainResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type domainResourceModel struct {
@@ -39,14 +39,22 @@ func (r *domainResource) Metadata(_ context.Context, req resource.MetadataReques
 	resp.TypeName = req.ProviderTypeName + "_domain"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *domainResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *domainResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -82,8 +90,16 @@ func (r *domainResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Read domains
-	exists, err := r.client.GlobalDomainExists(ctx, state.Domain.ValueString())
+	exists, err := client.GlobalDomainExists(ctx, state.Domain.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check global domain existence", "Unable to check global domain existence. "+err.Error())
 		return
@@ -111,8 +127,16 @@ func (r *domainResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Read domains
-	exists, err := r.client.GlobalDomainExists(ctx, plan.Domain.ValueString())
+	exists, err := client.GlobalDomainExists(ctx, plan.Domain.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check global domain existence", "Unable to check global domain existence. "+err.Error())
 		return
@@ -123,7 +147,7 @@ func (r *domainResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	// Add domain
-	err = r.client.GlobalDomainAdd(ctx, plan.Domain.ValueString())
+	err = client.GlobalDomainAdd(ctx, plan.Domain.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to add global domain", "Unable to add global domain. "+err.Error())
 		return
@@ -152,8 +176,16 @@ func (r *domainResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Read domains
-	exists, err := r.client.GlobalDomainExists(ctx, state.Domain.ValueString())
+	exists, err := client.GlobalDomainExists(ctx, state.Domain.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check global domain existence", "Unable to check global domain existence. "+err.Error())
 		return
@@ -163,7 +195,7 @@ func (r *domainResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	}
 
 	// Clear domains
-	err = r.client.GlobalDomainRemove(ctx, state.Domain.ValueString())
+	err = client.GlobalDomainRemove(ctx, state.Domain.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to remove global domain", "Unable to remove global domain. "+err.Error())
 		return

--- a/provider/http_auth_resource.go
+++ b/provider/http_auth_resource.go
@@ -2,11 +2,11 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
-	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
-
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -30,7 +30,7 @@ func NewHttpAuthResource() resource.Resource {
 }
 
 type httpAuthResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type httpAuthResourceModel struct {
@@ -47,14 +47,22 @@ func (r *httpAuthResource) Metadata(_ context.Context, req resource.MetadataRequ
 	resp.TypeName = req.ProviderTypeName + "_http_auth"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *httpAuthResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *httpAuthResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -108,8 +116,16 @@ func (r *httpAuthResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check http auth enabled
-	enabled, existingUsers, err := r.client.HttpAuthReport(ctx, state.AppName.ValueString())
+	enabled, existingUsers, err := client.HttpAuthReport(ctx, state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check http auth enabled", "Unable to check http auth enabled. "+err.Error())
 		return
@@ -150,7 +166,15 @@ func (r *httpAuthResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	enabled, existingUsers, err := r.client.HttpAuthReport(ctx, plan.AppName.ValueString())
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
+	enabled, existingUsers, err := client.HttpAuthReport(ctx, plan.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check http auth enabled", "Unable to check http auth enabled. "+err.Error())
 		return
@@ -160,7 +184,7 @@ func (r *httpAuthResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	err = r.client.HttpAuthEnable(ctx, plan.AppName.ValueString())
+	err = client.HttpAuthEnable(ctx, plan.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to enable http-auth", "Unable to enable http-auth. "+err.Error())
 		return
@@ -168,21 +192,21 @@ func (r *httpAuthResource) Create(ctx context.Context, req resource.CreateReques
 
 	// remove all users if present
 	for _, u := range existingUsers {
-		err := r.client.HttpAuthRemoveUser(ctx, plan.AppName.ValueString(), u)
+		err := client.HttpAuthRemoveUser(ctx, plan.AppName.ValueString(), u)
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to remove user", "Unable to remove user. "+err.Error())
 		}
 	}
 
 	for user, userData := range plan.Users {
-		err := r.client.HttpAuthAddUser(ctx, plan.AppName.ValueString(), user, userData.Password.ValueString())
+		err := client.HttpAuthAddUser(ctx, plan.AppName.ValueString(), user, userData.Password.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to add http-auth user", "Unable to add http-auth user. "+err.Error())
 		}
 	}
 
 	if resp.Diagnostics.HasError() {
-		err := r.client.HttpAuthDisable(ctx, plan.AppName.ValueString())
+		err := client.HttpAuthDisable(ctx, plan.AppName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to disable http-auth", "Unable to disable http-auth. "+err.Error())
 		}
@@ -213,6 +237,14 @@ func (r *httpAuthResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	if plan.AppName.ValueString() != state.AppName.ValueString() {
 		resp.Diagnostics.AddAttributeError(path.Root("app_name"), "App name can't be changed", "App name can't be changed")
 		return
@@ -227,7 +259,7 @@ func (r *httpAuthResource) Update(ctx context.Context, req resource.UpdateReques
 			}
 		}
 		if !found {
-			err := r.client.HttpAuthRemoveUser(ctx, state.AppName.ValueString(), existingUser)
+			err := client.HttpAuthRemoveUser(ctx, state.AppName.ValueString(), existingUser)
 			if err != nil {
 				resp.Diagnostics.AddAttributeError(path.Root("users").AtMapKey(existingUser), "Unable to remove user", "Unable to remove user. "+err.Error())
 				return
@@ -236,7 +268,7 @@ func (r *httpAuthResource) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	for user, userData := range plan.Users {
-		err := r.client.HttpAuthAddUser(ctx, plan.AppName.ValueString(), user, userData.Password.ValueString())
+		err := client.HttpAuthAddUser(ctx, plan.AppName.ValueString(), user, userData.Password.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to add http-auth user", "Unable to add http-auth user. "+err.Error())
 			return
@@ -264,7 +296,15 @@ func (r *httpAuthResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
-	err := r.client.HttpAuthDisable(ctx, state.AppName.ValueString())
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
+	err = client.HttpAuthDisable(ctx, state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to disable http-auth", "Unable to disable http-auth. "+err.Error())
 		return

--- a/provider/letsencrypt_resource.go
+++ b/provider/letsencrypt_resource.go
@@ -2,11 +2,11 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
-	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
-
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -28,7 +28,7 @@ func NewLetsencryptResource() resource.Resource {
 }
 
 type letsencryptResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type letsencryptResourceModel struct {
@@ -41,14 +41,22 @@ func (r *letsencryptResource) Metadata(_ context.Context, req resource.MetadataR
 	resp.TypeName = req.ProviderTypeName + "_letsencrypt"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *letsencryptResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *letsencryptResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -90,8 +98,16 @@ func (r *letsencryptResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Read letsencrypt status
-	exists, err := r.client.LetsencryptIsEnabled(ctx, state.AppName.ValueString())
+	exists, err := client.LetsencryptIsEnabled(ctx, state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to read letsencrypt status", "Unable to read letsencrypt status. "+err.Error())
 		return
@@ -119,8 +135,16 @@ func (r *letsencryptResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Read letsencrypt status
-	exists, err := r.client.LetsencryptIsEnabled(ctx, plan.AppName.ValueString())
+	exists, err := client.LetsencryptIsEnabled(ctx, plan.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to read letsencrypt status", "Unable to read letsencrypt status. "+err.Error())
 		return
@@ -131,21 +155,21 @@ func (r *letsencryptResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	// Set letsencrypt email
-	err = r.client.LetsencryptSetEmail(ctx, plan.AppName.ValueString(), plan.Email.ValueString())
+	err = client.LetsencryptSetEmail(ctx, plan.AppName.ValueString(), plan.Email.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to set letsencrypt email", "Unable to set letsencrypt email. "+err.Error())
 		return
 	}
 
 	// Enable letsencrypt
-	err = r.client.LetsencryptEnable(ctx, plan.AppName.ValueString())
+	err = client.LetsencryptEnable(ctx, plan.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to enable letsencrypt", "Unable to enable letsencrypt. "+err.Error())
 		return
 	}
 
 	// Add cronjob for auto-renew
-	err = r.client.LetsencryptAddCronJob(ctx)
+	err = client.LetsencryptAddCronJob(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to add letsencrypt cronjob", "Unable to add letsencrypt cronjob. "+err.Error())
 		return
@@ -180,7 +204,15 @@ func (r *letsencryptResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	err := r.client.LetsencryptSetEmail(ctx, plan.AppName.ValueString(), plan.Email.ValueString())
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
+	err = client.LetsencryptSetEmail(ctx, plan.AppName.ValueString(), plan.Email.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to set letsencrypt email", "Unable to set letsencrypt email. "+err.Error())
 		return
@@ -203,8 +235,16 @@ func (r *letsencryptResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Read letsencrypt status
-	exists, err := r.client.LetsencryptIsEnabled(ctx, state.AppName.ValueString())
+	exists, err := client.LetsencryptIsEnabled(ctx, state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to read letsencrypt status", "Unable to read letsencrypt status. "+err.Error())
 		return
@@ -214,7 +254,7 @@ func (r *letsencryptResource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 
 	// Disable letsencrypt
-	err = r.client.LetsencryptDisable(ctx, state.AppName.ValueString())
+	err = client.LetsencryptDisable(ctx, state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to disable letsencrypt", "Unable to disable letsencrypt. "+err.Error())
 		return

--- a/provider/nginx_config_resource.go
+++ b/provider/nginx_config_resource.go
@@ -2,11 +2,11 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
-	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
-
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -30,7 +30,7 @@ func NewNginxConfigResource() resource.Resource {
 }
 
 type nginxConfigResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type nginxConfigResourceModel struct {
@@ -44,14 +44,22 @@ func (r *nginxConfigResource) Metadata(_ context.Context, req resource.MetadataR
 	resp.TypeName = req.ProviderTypeName + "_nginx_config"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *nginxConfigResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *nginxConfigResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -128,9 +136,17 @@ func (r *nginxConfigResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Read
 	for property := range state.Config {
-		value, err := r.client.NginxConfigGetValue(ctx, appName, property)
+		value, err := client.NginxConfigGetValue(ctx, appName, property)
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to read nginxConfig property"+property, "Unable to read nginxConfig property"+property+". "+err.Error())
 			return
@@ -165,16 +181,24 @@ func (r *nginxConfigResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Create
 	for property := range plan.Config {
-		err := r.client.NginxConfigSetValue(ctx, appName, property, plan.Config[property].ValueString())
+		err := client.NginxConfigSetValue(ctx, appName, property, plan.Config[property].ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to set nginxConfig property", "Unable to set nginxConfig property. "+err.Error())
 			return
 		}
 	}
 
-	err := r.client.ProxyBuildConfig(ctx, appName)
+	err = client.ProxyBuildConfig(ctx, appName)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to rebuild nginxConfig for app", "Unable to rebuild nginxConfig for app. "+err.Error())
 		return
@@ -213,10 +237,18 @@ func (r *nginxConfigResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Update
 	var updatedProperties []string
 	for property := range plan.Config {
-		err := r.client.NginxConfigSetValue(ctx, appName, property, plan.Config[property].ValueString())
+		err := client.NginxConfigSetValue(ctx, appName, property, plan.Config[property].ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to set nginxConfig property", "Unable to set nginxConfig property. "+err.Error())
 			return
@@ -232,7 +264,7 @@ func (r *nginxConfigResource) Update(ctx context.Context, req resource.UpdateReq
 			}
 		}
 		if !presentInPlan {
-			err := r.client.NginxConfigResetValue(ctx, appName, property)
+			err := client.NginxConfigResetValue(ctx, appName, property)
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to reset nginxConfig property", "Unable to reset nginxConfig property. "+err.Error())
 				return
@@ -240,7 +272,7 @@ func (r *nginxConfigResource) Update(ctx context.Context, req resource.UpdateReq
 		}
 	}
 
-	err := r.client.ProxyBuildConfig(ctx, appName)
+	err = client.ProxyBuildConfig(ctx, appName)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to rebuild nginxConfig for app", "Unable to rebuild nginxConfig for app. "+err.Error())
 		return
@@ -276,15 +308,23 @@ func (r *nginxConfigResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	for property := range state.Config {
-		err := r.client.NginxConfigResetValue(ctx, appName, property)
+		err := client.NginxConfigResetValue(ctx, appName, property)
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to reset nginxConfig property", "Unable to reset nginxConfig property. "+err.Error())
 			return
 		}
 	}
 
-	err := r.client.ProxyBuildConfig(ctx, appName)
+	err = client.ProxyBuildConfig(ctx, appName)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to rebuild nginxConfig for app", "Unable to rebuild nginxConfig for app. "+err.Error())
 		return

--- a/provider/plugin_resource.go
+++ b/provider/plugin_resource.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
-
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -27,7 +26,7 @@ func NewPluginResource() resource.Resource {
 }
 
 type pluginResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type pluginResourceModel struct {
@@ -41,13 +40,21 @@ func (r *pluginResource) Metadata(_ context.Context, req resource.MetadataReques
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *pluginResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+func (r *pluginResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -94,8 +101,16 @@ func (r *pluginResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Read plugin
-	found, err := r.client.PluginIsInstalled(ctx, state.Name.ValueString())
+	found, err := client.PluginIsInstalled(ctx, state.Name.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to read plugin", "Unable to read plugin. "+err.Error())
 		return
@@ -123,9 +138,17 @@ func (r *pluginResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Can't install the plugin because it requires root rights
 	// Therefore, simply check that the plugin is installed and, if it is not, throw an error
-	found, err := r.client.PluginIsInstalled(ctx, plan.Name.ValueString())
+	found, err := client.PluginIsInstalled(ctx, plan.Name.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to read plugin", "Unable to read plugin. "+err.Error())
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -10,10 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
+	configpkg "github.com/aliksend/terraform-provider-dokku/internal/config"
 	"github.com/aliksend/terraform-provider-dokku/provider/services"
-
-	"github.com/blang/semver"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -263,79 +261,38 @@ func (p *dokkuProvider) Configure(ctx context.Context, req provider.ConfigureReq
 		return
 	}
 
-	tflog.Debug(ctx, "cert", map[string]any{"path": sshCertPath})
+	tflog.Debug(ctx, "Provider configuration", map[string]any{"host": host, "port": port, "user": sshUsername})
 
-	sshAuth, err := goph.Key(sshCertPath, "")
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(path.Root("ssh_cert"), "Unable to find cert for ssh", "Unable to find cert for ssh. "+err.Error())
-		return
-	}
-
-	tflog.Debug(ctx, "ssh connection", map[string]any{"host": host, "port": port, "user": sshUsername})
-
+	// Parse host key configuration
 	skipHostKeyCheck := false
 	if !config.SshSkipHostKeyCheck.IsNull() {
 		skipHostKeyCheck = config.SshSkipHostKeyCheck.ValueBool()
 	}
 
-	sshConfig := &goph.Config{
-		Auth:     sshAuth,
-		Addr:     host,
-		Port:     port,
-		User:     sshUsername,
-		Callback: verifyHost,
+	hostKey := ""
+	if !config.SshHostKey.IsNull() {
+		hostKey = config.SshHostKey.ValueString()
 	}
 
-	if skipHostKeyCheck {
-		sshConfig.Callback = ssh.InsecureIgnoreHostKey()
-	} else if !config.SshHostKey.IsNull() {
-		_, _, publicKey, _, _, err := ssh.ParseKnownHosts([]byte(config.SshHostKey.ValueString()))
-		if err != nil {
-			resp.Diagnostics.AddError("Unable to parse provided ssh_host_key", "Unable to parse provided ssh_host_key. "+err.Error())
-			return
-		}
-		sshConfig.Callback = ssh.FixedHostKey(publicKey)
+	// Create DokkuConfig for lazy connection establishment
+	dokkuConfig := &configpkg.DokkuConfig{
+		Host:             host,
+		Port:             port,
+		User:             sshUsername,
+		CertPath:         sshCertPath,
+		SkipHostKeyCheck: skipHostKeyCheck,
+		HostKey:          hostKey,
+		LogSshCommands:   logSshCommands,
+		UploadAppName:    uploadAppName,
+		UploadSplitBytes: uploadSplitBytes,
 	}
 
-	client, err := goph.NewConn(sshConfig)
-	if err != nil {
-		resp.Diagnostics.AddError("Unable to establish SSH connection", "Unable to establish SSH connection. "+err.Error())
-		return
-	}
+	tflog.Debug(ctx, "Provider configured for lazy SSH connections")
 
-	dokkuClient := dokkuclient.New(client, logSshCommands, uploadAppName, uploadSplitBytes)
-	rawVersion, version, err := dokkuClient.GetVersion(ctx)
-	if err != nil {
-		if err == dokkuclient.ErrInvalidUser {
-			resp.Diagnostics.AddError(err.Error(), err.Error())
-		} else {
-			resp.Diagnostics.AddError("unable go get dokku version", "unable go get dokku version")
-		}
-		return
-	}
-
-	testedVersions := ">=0.24.0 <= 0.34.7"
-	testedErrMsg := fmt.Sprintf("This provider has not been tested against Dokku version %s. Tested version range: %s", rawVersion, testedVersions)
-
-	if err == nil {
-		tflog.Debug(ctx, "host version", map[string]any{"version": version})
-
-		compat := semver.MustParseRange(testedVersions)
-
-		if !compat(version) {
-			resp.Diagnostics.AddWarning(testedErrMsg, testedErrMsg)
-		}
-	} else {
-		resp.Diagnostics.AddError("Unable to detect dokku version", "Unable to detect dokku version. "+err.Error())
-		return
-	}
-
-	tflog.Debug(ctx, "Connected!")
-
-	// Make the dokku client available during DataSource and Resource
-	// type Configure methods.
-	resp.DataSourceData = dokkuClient
-	resp.ResourceData = dokkuClient
+	// Make the dokku config available during DataSource and Resource
+	// type Configure methods - connections will be established on-demand
+	resp.DataSourceData = dokkuConfig
+	resp.ResourceData = dokkuConfig
 }
 
 func (p *dokkuProvider) Resources(ctx context.Context) []func() resource.Resource {

--- a/provider/services/clickhouse_link_resource.go
+++ b/provider/services/clickhouse_link_resource.go
@@ -2,9 +2,11 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -28,7 +30,7 @@ func NewClickhouseLinkResource() resource.Resource {
 }
 
 type clickhouseLinkResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type clickhouseLinkResourceModel struct {
@@ -42,14 +44,22 @@ func (r *clickhouseLinkResource) Metadata(_ context.Context, req resource.Metada
 	resp.TypeName = req.ProviderTypeName + "_clickhouse_link"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *clickhouseLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *clickhouseLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -100,8 +110,16 @@ func (r *clickhouseLinkResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "clickhouse", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "clickhouse", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check clickhouse service existence", "Unable to check clickhouse service existence. "+err.Error())
 		return
@@ -112,7 +130,7 @@ func (r *clickhouseLinkResource) Read(ctx context.Context, req resource.ReadRequ
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "clickhouse", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "clickhouse", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check clickhouse link existence", "Unable to check clickhouse link existence. "+err.Error())
 		return
@@ -140,8 +158,16 @@ func (r *clickhouseLinkResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "clickhouse", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "clickhouse", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check clickhouse service existence", "Unable to check clickhouse service existence. "+err.Error())
 		return
@@ -152,7 +178,7 @@ func (r *clickhouseLinkResource) Create(ctx context.Context, req resource.Create
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "clickhouse", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "clickhouse", plan.ServiceName.ValueString(), plan.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check clickhouse link existence", "Unable to check clickhouse link existence. "+err.Error())
 		return
@@ -168,7 +194,7 @@ func (r *clickhouseLinkResource) Create(ctx context.Context, req resource.Create
 	}
 
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "clickhouse", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
+	err = client.SimpleServiceLinkCreate(ctx, "clickhouse", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create clickhouse link", "Unable to create clickhouse link. "+err.Error())
 		return
@@ -197,8 +223,16 @@ func (r *clickhouseLinkResource) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "clickhouse", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "clickhouse", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check clickhouse service existence", "Unable to check clickhouse service existence. "+err.Error())
 		return
@@ -208,7 +242,7 @@ func (r *clickhouseLinkResource) Delete(ctx context.Context, req resource.Delete
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "clickhouse", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "clickhouse", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check clickhouse link existence", "Unable to check clickhouse link existence. "+err.Error())
 		return
@@ -218,7 +252,7 @@ func (r *clickhouseLinkResource) Delete(ctx context.Context, req resource.Delete
 	}
 
 	// Unlink service
-	err = r.client.SimpleServiceLinkRemove(ctx, "clickhouse", state.ServiceName.ValueString(), state.AppName.ValueString())
+	err = client.SimpleServiceLinkRemove(ctx, "clickhouse", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to unlink service from app", "Unable to unlink service from app. "+err.Error())
 		return

--- a/provider/services/clickhouse_resource.go
+++ b/provider/services/clickhouse_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -29,7 +29,7 @@ func NewClickhouseResource() resource.Resource {
 }
 
 type clickhouseResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type clickhouseResourceModel struct {
@@ -43,14 +43,22 @@ func (r *clickhouseResource) Metadata(_ context.Context, req resource.MetadataRe
 	resp.TypeName = req.ProviderTypeName + "_clickhouse"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *clickhouseResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *clickhouseResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -99,8 +107,16 @@ func (r *clickhouseResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "clickhouse", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "clickhouse", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check clickhouse service existence", "Unable to check clickhouse service existence. "+err.Error())
 		return
@@ -110,7 +126,7 @@ func (r *clickhouseResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	info, err := r.client.SimpleServiceInfo(ctx, "clickhouse", state.ServiceName.ValueString())
+	info, err := client.SimpleServiceInfo(ctx, "clickhouse", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to get clickhouse service info", "Unable to get clickhouse service info. "+err.Error())
 		return
@@ -149,8 +165,16 @@ func (r *clickhouseResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Create service is not exists
-	exists, err := r.client.SimpleServiceExists(ctx, "clickhouse", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "clickhouse", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check clickhouse service existence", "Unable to check clickhouse service existence. "+err.Error())
 		return
@@ -172,14 +196,14 @@ func (r *clickhouseResource) Create(ctx context.Context, req resource.CreateRequ
 		}
 	}
 
-	err = r.client.SimpleServiceCreate(ctx, "clickhouse", plan.ServiceName.ValueString(), args...)
+	err = client.SimpleServiceCreate(ctx, "clickhouse", plan.ServiceName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create clickhouse service", "Unable to create clickhouse service. "+err.Error())
 		return
 	}
 
 	if !plan.Expose.IsNull() {
-		err := r.client.SimpleServiceExpose(ctx, "clickhouse", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+		err := client.SimpleServiceExpose(ctx, "clickhouse", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to expose clickhouse service", "Unable to expose clickhouse service. "+err.Error())
 			return
@@ -210,26 +234,34 @@ func (r *clickhouseResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	if plan.ServiceName.ValueString() != state.ServiceName.ValueString() {
 		resp.Diagnostics.AddError("service_name can't be changed", "service_name can't be changed")
 	}
 
 	if !plan.Expose.IsNull() {
 		if !plan.Expose.Equal(state.Expose) {
-			err := r.client.SimpleServiceUnexpose(ctx, "clickhouse", state.ServiceName.ValueString())
+			err := client.SimpleServiceUnexpose(ctx, "clickhouse", state.ServiceName.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to unexpose clickhouse service", "Unable to unexpose clickhouse service. "+err.Error())
 				return
 			}
 
-			err = r.client.SimpleServiceExpose(ctx, "clickhouse", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+			err = client.SimpleServiceExpose(ctx, "clickhouse", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to expose clickhouse service", "Unable to expose clickhouse service. "+err.Error())
 				return
 			}
 		}
 	} else if !state.Expose.IsNull() {
-		err := r.client.SimpleServiceUnexpose(ctx, "clickhouse", state.ServiceName.ValueString())
+		err := client.SimpleServiceUnexpose(ctx, "clickhouse", state.ServiceName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to unexpose clickhouse service", "Unable to unexpose clickhouse service. "+err.Error())
 			return
@@ -257,8 +289,16 @@ func (r *clickhouseResource) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "clickhouse", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "clickhouse", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check clickhouse service existence", "Unable to check clickhouse service existence. "+err.Error())
 		return
@@ -268,7 +308,7 @@ func (r *clickhouseResource) Delete(ctx context.Context, req resource.DeleteRequ
 	}
 
 	// Destroy instance
-	err = r.client.SimpleServiceDestroy(ctx, "clickhouse", state.ServiceName.ValueString())
+	err = client.SimpleServiceDestroy(ctx, "clickhouse", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to destroy service", "Unable to destroy service. "+err.Error())
 		return

--- a/provider/services/couchdb_link_resource.go
+++ b/provider/services/couchdb_link_resource.go
@@ -2,9 +2,11 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -28,7 +30,7 @@ func NewCouchDBLinkResource() resource.Resource {
 }
 
 type couchDBLinkResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type couchDBLinkResourceModel struct {
@@ -42,14 +44,22 @@ func (r *couchDBLinkResource) Metadata(_ context.Context, req resource.MetadataR
 	resp.TypeName = req.ProviderTypeName + "_couchdb_link"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *couchDBLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *couchDBLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -100,8 +110,16 @@ func (r *couchDBLinkResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "couchdb", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "couchdb", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check couchDB service existence", "Unable to check couchDB service existence. "+err.Error())
 		return
@@ -112,7 +130,7 @@ func (r *couchDBLinkResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "couchdb", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "couchdb", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check couchDB link existence", "Unable to check couchDB link existence. "+err.Error())
 		return
@@ -140,8 +158,16 @@ func (r *couchDBLinkResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "couchdb", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "couchdb", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check couchDB service existence", "Unable to check couchDB service existence. "+err.Error())
 		return
@@ -152,7 +178,7 @@ func (r *couchDBLinkResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "couchdb", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "couchdb", plan.ServiceName.ValueString(), plan.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check couchDB link existence", "Unable to check couchDB link existence. "+err.Error())
 		return
@@ -168,7 +194,7 @@ func (r *couchDBLinkResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "couchdb", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
+	err = client.SimpleServiceLinkCreate(ctx, "couchdb", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create couchDB link", "Unable to create couchDB link. "+err.Error())
 		return
@@ -197,8 +223,16 @@ func (r *couchDBLinkResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "couchdb", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "couchdb", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check couchDB service existence", "Unable to check couchDB service existence. "+err.Error())
 		return
@@ -208,7 +242,7 @@ func (r *couchDBLinkResource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "couchdb", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "couchdb", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check couchDB link existence", "Unable to check couchDB link existence. "+err.Error())
 		return
@@ -218,7 +252,7 @@ func (r *couchDBLinkResource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 
 	// Unlink service
-	err = r.client.SimpleServiceLinkRemove(ctx, "couchdb", state.ServiceName.ValueString(), state.AppName.ValueString())
+	err = client.SimpleServiceLinkRemove(ctx, "couchdb", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to unlink service from app", "Unable to unlink service from app. "+err.Error())
 		return

--- a/provider/services/couchdb_resource.go
+++ b/provider/services/couchdb_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -29,7 +29,7 @@ func NewCouchDBResource() resource.Resource {
 }
 
 type couchDBResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type couchDBResourceModel struct {
@@ -43,14 +43,22 @@ func (r *couchDBResource) Metadata(_ context.Context, req resource.MetadataReque
 	resp.TypeName = req.ProviderTypeName + "_couchdb"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *couchDBResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *couchDBResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -99,8 +107,16 @@ func (r *couchDBResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "couchdb", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "couchdb", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check couchDB service existence", "Unable to check couchDB service existence. "+err.Error())
 		return
@@ -110,7 +126,7 @@ func (r *couchDBResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	info, err := r.client.SimpleServiceInfo(ctx, "couchdb", state.ServiceName.ValueString())
+	info, err := client.SimpleServiceInfo(ctx, "couchdb", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to get couchdb service info", "Unable to get couchdb service info. "+err.Error())
 		return
@@ -149,8 +165,16 @@ func (r *couchDBResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Create service is not exists
-	exists, err := r.client.SimpleServiceExists(ctx, "couchdb", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "couchdb", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check couchDB service existence", "Unable to check couchDB service existence. "+err.Error())
 		return
@@ -172,14 +196,14 @@ func (r *couchDBResource) Create(ctx context.Context, req resource.CreateRequest
 		}
 	}
 
-	err = r.client.SimpleServiceCreate(ctx, "couchdb", plan.ServiceName.ValueString())
+	err = client.SimpleServiceCreate(ctx, "couchdb", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create couchDB service", "Unable to create couchDB service. "+err.Error())
 		return
 	}
 
 	if !plan.Expose.IsNull() {
-		err := r.client.SimpleServiceExpose(ctx, "couchdb", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+		err := client.SimpleServiceExpose(ctx, "couchdb", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to expose couchdb service", "Unable to expose couchdb service. "+err.Error())
 			return
@@ -210,26 +234,34 @@ func (r *couchDBResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	if plan.ServiceName.ValueString() != state.ServiceName.ValueString() {
 		resp.Diagnostics.AddError("service_name can't be changed", "service_name can't be changed")
 	}
 
 	if !plan.Expose.IsNull() {
 		if !plan.Expose.Equal(state.Expose) {
-			err := r.client.SimpleServiceUnexpose(ctx, "couchdb", state.ServiceName.ValueString())
+			err := client.SimpleServiceUnexpose(ctx, "couchdb", state.ServiceName.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to unexpose couchdb service", "Unable to unexpose couchdb service. "+err.Error())
 				return
 			}
 
-			err = r.client.SimpleServiceExpose(ctx, "couchdb", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+			err = client.SimpleServiceExpose(ctx, "couchdb", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to expose couchdb service", "Unable to expose couchdb service. "+err.Error())
 				return
 			}
 		}
 	} else if !state.Expose.IsNull() {
-		err := r.client.SimpleServiceUnexpose(ctx, "couchdb", state.ServiceName.ValueString())
+		err := client.SimpleServiceUnexpose(ctx, "couchdb", state.ServiceName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to unexpose couchdb service", "Unable to unexpose couchdb service. "+err.Error())
 			return
@@ -257,8 +289,16 @@ func (r *couchDBResource) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "couchdb", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "couchdb", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check couchDB service existence", "Unable to check couchDB service existence. "+err.Error())
 		return
@@ -268,7 +308,7 @@ func (r *couchDBResource) Delete(ctx context.Context, req resource.DeleteRequest
 	}
 
 	// Destroy instance
-	err = r.client.SimpleServiceDestroy(ctx, "couchdb", state.ServiceName.ValueString())
+	err = client.SimpleServiceDestroy(ctx, "couchdb", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to destroy service", "Unable to destroy service. "+err.Error())
 		return

--- a/provider/services/elasticsearch_link_resource.go
+++ b/provider/services/elasticsearch_link_resource.go
@@ -2,9 +2,11 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -28,7 +30,7 @@ func NewElasticsearchLinkResource() resource.Resource {
 }
 
 type elasticsearchLinkResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type elasticsearchLinkResourceModel struct {
@@ -42,14 +44,22 @@ func (r *elasticsearchLinkResource) Metadata(_ context.Context, req resource.Met
 	resp.TypeName = req.ProviderTypeName + "_elasticsearch_link"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *elasticsearchLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *elasticsearchLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -100,8 +110,16 @@ func (r *elasticsearchLinkResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "elasticsearch", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "elasticsearch", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check elasticsearch service existence", "Unable to check elasticsearch service existence. "+err.Error())
 		return
@@ -112,7 +130,7 @@ func (r *elasticsearchLinkResource) Read(ctx context.Context, req resource.ReadR
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "elasticsearch", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "elasticsearch", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check elasticsearch link existence", "Unable to check elasticsearch link existence. "+err.Error())
 		return
@@ -140,8 +158,16 @@ func (r *elasticsearchLinkResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "elasticsearch", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "elasticsearch", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check elasticsearch service existence", "Unable to check elasticsearch service existence. "+err.Error())
 		return
@@ -152,7 +178,7 @@ func (r *elasticsearchLinkResource) Create(ctx context.Context, req resource.Cre
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "elasticsearch", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "elasticsearch", plan.ServiceName.ValueString(), plan.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check elasticsearch link existence", "Unable to check elasticsearch link existence. "+err.Error())
 		return
@@ -168,7 +194,7 @@ func (r *elasticsearchLinkResource) Create(ctx context.Context, req resource.Cre
 	}
 
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "elasticsearch", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
+	err = client.SimpleServiceLinkCreate(ctx, "elasticsearch", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create elasticsearch link", "Unable to create elasticsearch link. "+err.Error())
 		return
@@ -197,8 +223,16 @@ func (r *elasticsearchLinkResource) Delete(ctx context.Context, req resource.Del
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "elasticsearch", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "elasticsearch", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check elasticsearch service existence", "Unable to check elasticsearch service existence. "+err.Error())
 		return
@@ -208,7 +242,7 @@ func (r *elasticsearchLinkResource) Delete(ctx context.Context, req resource.Del
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "elasticsearch", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "elasticsearch", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check elasticsearch link existence", "Unable to check elasticsearch link existence. "+err.Error())
 		return
@@ -218,7 +252,7 @@ func (r *elasticsearchLinkResource) Delete(ctx context.Context, req resource.Del
 	}
 
 	// Unlink service
-	err = r.client.SimpleServiceLinkRemove(ctx, "elasticsearch", state.ServiceName.ValueString(), state.AppName.ValueString())
+	err = client.SimpleServiceLinkRemove(ctx, "elasticsearch", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to unlink service from app", "Unable to unlink service from app. "+err.Error())
 		return

--- a/provider/services/elasticsearch_resource.go
+++ b/provider/services/elasticsearch_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -29,7 +29,7 @@ func NewElasticsearchResource() resource.Resource {
 }
 
 type elasticsearchResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type elasticsearchResourceModel struct {
@@ -43,14 +43,22 @@ func (r *elasticsearchResource) Metadata(_ context.Context, req resource.Metadat
 	resp.TypeName = req.ProviderTypeName + "_elasticsearch"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *elasticsearchResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *elasticsearchResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -99,8 +107,16 @@ func (r *elasticsearchResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "elasticsearch", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "elasticsearch", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check elasticsearch service existence", "Unable to check elasticsearch service existence. "+err.Error())
 		return
@@ -110,7 +126,7 @@ func (r *elasticsearchResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	info, err := r.client.SimpleServiceInfo(ctx, "elasticsearch", state.ServiceName.ValueString())
+	info, err := client.SimpleServiceInfo(ctx, "elasticsearch", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to get elasticsearch service info", "Unable to get elasticsearch service info. "+err.Error())
 		return
@@ -149,8 +165,16 @@ func (r *elasticsearchResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Create service is not exists
-	exists, err := r.client.SimpleServiceExists(ctx, "elasticsearch", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "elasticsearch", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check elasticsearch service existence", "Unable to check elasticsearch service existence. "+err.Error())
 		return
@@ -172,14 +196,14 @@ func (r *elasticsearchResource) Create(ctx context.Context, req resource.CreateR
 		}
 	}
 
-	err = r.client.SimpleServiceCreate(ctx, "elasticsearch", plan.ServiceName.ValueString())
+	err = client.SimpleServiceCreate(ctx, "elasticsearch", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create elasticsearch service", "Unable to create elasticsearch service. "+err.Error())
 		return
 	}
 
 	if !plan.Expose.IsNull() {
-		err := r.client.SimpleServiceExpose(ctx, "elasticsearch", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+		err := client.SimpleServiceExpose(ctx, "elasticsearch", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to expose elasticsearch service", "Unable to expose elasticsearch service. "+err.Error())
 			return
@@ -210,26 +234,34 @@ func (r *elasticsearchResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	if plan.ServiceName.ValueString() != state.ServiceName.ValueString() {
 		resp.Diagnostics.AddError("service_name can't be changed", "service_name can't be changed")
 	}
 
 	if !plan.Expose.IsNull() {
 		if !plan.Expose.Equal(state.Expose) {
-			err := r.client.SimpleServiceUnexpose(ctx, "elasticsearch", state.ServiceName.ValueString())
+			err := client.SimpleServiceUnexpose(ctx, "elasticsearch", state.ServiceName.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to unexpose elasticsearch service", "Unable to unexpose elasticsearch service. "+err.Error())
 				return
 			}
 
-			err = r.client.SimpleServiceExpose(ctx, "elasticsearch", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+			err = client.SimpleServiceExpose(ctx, "elasticsearch", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to expose elasticsearch service", "Unable to expose elasticsearch service. "+err.Error())
 				return
 			}
 		}
 	} else if !state.Expose.IsNull() {
-		err := r.client.SimpleServiceUnexpose(ctx, "elasticsearch", state.ServiceName.ValueString())
+		err := client.SimpleServiceUnexpose(ctx, "elasticsearch", state.ServiceName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to unexpose elasticsearch service", "Unable to unexpose elasticsearch service. "+err.Error())
 			return
@@ -257,8 +289,16 @@ func (r *elasticsearchResource) Delete(ctx context.Context, req resource.DeleteR
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "elasticsearch", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "elasticsearch", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check elasticsearch service existence", "Unable to check elasticsearch service existence. "+err.Error())
 		return
@@ -268,7 +308,7 @@ func (r *elasticsearchResource) Delete(ctx context.Context, req resource.DeleteR
 	}
 
 	// Destroy instance
-	err = r.client.SimpleServiceDestroy(ctx, "elasticsearch", state.ServiceName.ValueString())
+	err = client.SimpleServiceDestroy(ctx, "elasticsearch", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to destroy service", "Unable to destroy service. "+err.Error())
 		return

--- a/provider/services/mariadb_link_resource.go
+++ b/provider/services/mariadb_link_resource.go
@@ -2,9 +2,11 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -28,7 +30,7 @@ func NewMariaDBLinkResource() resource.Resource {
 }
 
 type mariaDBLinkResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type mariaDBLinkResourceModel struct {
@@ -42,14 +44,22 @@ func (r *mariaDBLinkResource) Metadata(_ context.Context, req resource.MetadataR
 	resp.TypeName = req.ProviderTypeName + "_mariadb_link"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *mariaDBLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *mariaDBLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -100,8 +110,16 @@ func (r *mariaDBLinkResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "mariadb", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "mariadb", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mariaDB service existence", "Unable to check mariaDB service existence. "+err.Error())
 		return
@@ -112,7 +130,7 @@ func (r *mariaDBLinkResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "mariadb", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "mariadb", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mariaDB link existence", "Unable to check mariaDB link existence. "+err.Error())
 		return
@@ -140,8 +158,16 @@ func (r *mariaDBLinkResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "mariadb", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "mariadb", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mariaDB service existence", "Unable to check mariaDB service existence. "+err.Error())
 		return
@@ -152,7 +178,7 @@ func (r *mariaDBLinkResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "mariadb", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "mariadb", plan.ServiceName.ValueString(), plan.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mariaDB link existence", "Unable to check mariaDB link existence. "+err.Error())
 		return
@@ -168,7 +194,7 @@ func (r *mariaDBLinkResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "mariadb", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
+	err = client.SimpleServiceLinkCreate(ctx, "mariadb", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create mariaDB link", "Unable to create mariaDB link. "+err.Error())
 		return
@@ -197,8 +223,16 @@ func (r *mariaDBLinkResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "mariadb", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "mariadb", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mariaDB service existence", "Unable to check mariaDB service existence. "+err.Error())
 		return
@@ -208,7 +242,7 @@ func (r *mariaDBLinkResource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "mariadb", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "mariadb", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mariaDB link existence", "Unable to check mariaDB link existence. "+err.Error())
 		return
@@ -218,7 +252,7 @@ func (r *mariaDBLinkResource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 
 	// Unlink service
-	err = r.client.SimpleServiceLinkRemove(ctx, "mariadb", state.ServiceName.ValueString(), state.AppName.ValueString())
+	err = client.SimpleServiceLinkRemove(ctx, "mariadb", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to unlink service from app", "Unable to unlink service from app. "+err.Error())
 		return

--- a/provider/services/mariadb_resource.go
+++ b/provider/services/mariadb_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -29,7 +29,7 @@ func NewMariaDBResource() resource.Resource {
 }
 
 type mariaDBResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type mariaDBResourceModel struct {
@@ -43,14 +43,22 @@ func (r *mariaDBResource) Metadata(_ context.Context, req resource.MetadataReque
 	resp.TypeName = req.ProviderTypeName + "_mariadb"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *mariaDBResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *mariaDBResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -99,8 +107,16 @@ func (r *mariaDBResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "mariadb", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "mariadb", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mariaDB service existence", "Unable to check mariaDB service existence. "+err.Error())
 		return
@@ -110,7 +126,7 @@ func (r *mariaDBResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	info, err := r.client.SimpleServiceInfo(ctx, "mariadb", state.ServiceName.ValueString())
+	info, err := client.SimpleServiceInfo(ctx, "mariadb", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to get mariadb service info", "Unable to get mariadb service info. "+err.Error())
 		return
@@ -149,8 +165,16 @@ func (r *mariaDBResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Create service is not exists
-	exists, err := r.client.SimpleServiceExists(ctx, "mariadb", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "mariadb", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mariaDB service existence", "Unable to check mariaDB service existence. "+err.Error())
 		return
@@ -172,14 +196,14 @@ func (r *mariaDBResource) Create(ctx context.Context, req resource.CreateRequest
 		}
 	}
 
-	err = r.client.SimpleServiceCreate(ctx, "mariadb", plan.ServiceName.ValueString())
+	err = client.SimpleServiceCreate(ctx, "mariadb", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create mariaDB service", "Unable to create mariaDB service. "+err.Error())
 		return
 	}
 
 	if !plan.Expose.IsNull() {
-		err := r.client.SimpleServiceExpose(ctx, "mariadb", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+		err := client.SimpleServiceExpose(ctx, "mariadb", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to expose mariadb service", "Unable to expose mariadb service. "+err.Error())
 			return
@@ -210,26 +234,34 @@ func (r *mariaDBResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	if plan.ServiceName.ValueString() != state.ServiceName.ValueString() {
 		resp.Diagnostics.AddError("service_name can't be changed", "service_name can't be changed")
 	}
 
 	if !plan.Expose.IsNull() {
 		if !plan.Expose.Equal(state.Expose) {
-			err := r.client.SimpleServiceUnexpose(ctx, "mariadb", state.ServiceName.ValueString())
+			err := client.SimpleServiceUnexpose(ctx, "mariadb", state.ServiceName.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to unexpose mariadb service", "Unable to unexpose mariadb service. "+err.Error())
 				return
 			}
 
-			err = r.client.SimpleServiceExpose(ctx, "mariadb", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+			err = client.SimpleServiceExpose(ctx, "mariadb", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to expose mariadb service", "Unable to expose mariadb service. "+err.Error())
 				return
 			}
 		}
 	} else if !state.Expose.IsNull() {
-		err := r.client.SimpleServiceUnexpose(ctx, "mariadb", state.ServiceName.ValueString())
+		err := client.SimpleServiceUnexpose(ctx, "mariadb", state.ServiceName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to unexpose mariadb service", "Unable to unexpose mariadb service. "+err.Error())
 			return
@@ -257,8 +289,16 @@ func (r *mariaDBResource) Delete(ctx context.Context, req resource.DeleteRequest
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "mariadb", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "mariadb", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mariaDB service existence", "Unable to check mariaDB service existence. "+err.Error())
 		return
@@ -268,7 +308,7 @@ func (r *mariaDBResource) Delete(ctx context.Context, req resource.DeleteRequest
 	}
 
 	// Destroy instance
-	err = r.client.SimpleServiceDestroy(ctx, "mariadb", state.ServiceName.ValueString())
+	err = client.SimpleServiceDestroy(ctx, "mariadb", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to destroy service", "Unable to destroy service. "+err.Error())
 		return

--- a/provider/services/mongo_link_resource.go
+++ b/provider/services/mongo_link_resource.go
@@ -2,9 +2,11 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -28,7 +30,7 @@ func NewMongoLinkResource() resource.Resource {
 }
 
 type mongoLinkResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type mongoLinkResourceModel struct {
@@ -42,14 +44,22 @@ func (r *mongoLinkResource) Metadata(_ context.Context, req resource.MetadataReq
 	resp.TypeName = req.ProviderTypeName + "_mongo_link"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *mongoLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *mongoLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -100,8 +110,16 @@ func (r *mongoLinkResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "mongo", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "mongo", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mongo service existence", "Unable to check mongo service existence. "+err.Error())
 		return
@@ -112,7 +130,7 @@ func (r *mongoLinkResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "mongo", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "mongo", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mongo link existence", "Unable to check mongo link existence. "+err.Error())
 		return
@@ -140,8 +158,16 @@ func (r *mongoLinkResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "mongo", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "mongo", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mongo service existence", "Unable to check mongo service existence. "+err.Error())
 		return
@@ -152,7 +178,7 @@ func (r *mongoLinkResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "mongo", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "mongo", plan.ServiceName.ValueString(), plan.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mongo link existence", "Unable to check mongo link existence. "+err.Error())
 		return
@@ -168,7 +194,7 @@ func (r *mongoLinkResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "mongo", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
+	err = client.SimpleServiceLinkCreate(ctx, "mongo", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create mongo link", "Unable to create mongo link. "+err.Error())
 		return
@@ -197,8 +223,16 @@ func (r *mongoLinkResource) Delete(ctx context.Context, req resource.DeleteReque
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "mongo", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "mongo", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mongo service existence", "Unable to check mongo service existence. "+err.Error())
 		return
@@ -208,7 +242,7 @@ func (r *mongoLinkResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "mongo", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "mongo", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mongo link existence", "Unable to check mongo link existence. "+err.Error())
 		return
@@ -218,7 +252,7 @@ func (r *mongoLinkResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	// Unlink service
-	err = r.client.SimpleServiceLinkRemove(ctx, "mongo", state.ServiceName.ValueString(), state.AppName.ValueString())
+	err = client.SimpleServiceLinkRemove(ctx, "mongo", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to unlink service from app", "Unable to unlink service from app. "+err.Error())
 		return

--- a/provider/services/mongo_resource.go
+++ b/provider/services/mongo_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -29,7 +29,7 @@ func NewMongoResource() resource.Resource {
 }
 
 type mongoResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type mongoResourceModel struct {
@@ -43,14 +43,22 @@ func (r *mongoResource) Metadata(_ context.Context, req resource.MetadataRequest
 	resp.TypeName = req.ProviderTypeName + "_mongo"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *mongoResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *mongoResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -99,8 +107,16 @@ func (r *mongoResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "mongo", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "mongo", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mongo service existence", "Unable to check mongo service existence. "+err.Error())
 		return
@@ -110,7 +126,7 @@ func (r *mongoResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	info, err := r.client.SimpleServiceInfo(ctx, "mongo", state.ServiceName.ValueString())
+	info, err := client.SimpleServiceInfo(ctx, "mongo", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to get mongo service info", "Unable to get mongo service info. "+err.Error())
 		return
@@ -149,8 +165,16 @@ func (r *mongoResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Create service is not exists
-	exists, err := r.client.SimpleServiceExists(ctx, "mongo", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "mongo", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mongo service existence", "Unable to check mongo service existence. "+err.Error())
 		return
@@ -172,14 +196,14 @@ func (r *mongoResource) Create(ctx context.Context, req resource.CreateRequest, 
 		}
 	}
 
-	err = r.client.SimpleServiceCreate(ctx, "mongo", plan.ServiceName.ValueString())
+	err = client.SimpleServiceCreate(ctx, "mongo", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create mongo service", "Unable to create mongo service. "+err.Error())
 		return
 	}
 
 	if !plan.Expose.IsNull() {
-		err := r.client.SimpleServiceExpose(ctx, "mongo", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+		err := client.SimpleServiceExpose(ctx, "mongo", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to expose mongo service", "Unable to expose mongo service. "+err.Error())
 			return
@@ -210,26 +234,34 @@ func (r *mongoResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	if plan.ServiceName.ValueString() != state.ServiceName.ValueString() {
 		resp.Diagnostics.AddError("service_name can't be changed", "service_name can't be changed")
 	}
 
 	if !plan.Expose.IsNull() {
 		if !plan.Expose.Equal(state.Expose) {
-			err := r.client.SimpleServiceUnexpose(ctx, "mongo", state.ServiceName.ValueString())
+			err := client.SimpleServiceUnexpose(ctx, "mongo", state.ServiceName.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to unexpose mongo service", "Unable to unexpose mongo service. "+err.Error())
 				return
 			}
 
-			err = r.client.SimpleServiceExpose(ctx, "mongo", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+			err = client.SimpleServiceExpose(ctx, "mongo", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to expose mongo service", "Unable to expose mongo service. "+err.Error())
 				return
 			}
 		}
 	} else if !state.Expose.IsNull() {
-		err := r.client.SimpleServiceUnexpose(ctx, "mongo", state.ServiceName.ValueString())
+		err := client.SimpleServiceUnexpose(ctx, "mongo", state.ServiceName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to unexpose mongo service", "Unable to unexpose mongo service. "+err.Error())
 			return
@@ -257,8 +289,16 @@ func (r *mongoResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "mongo", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "mongo", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mongo service existence", "Unable to check mongo service existence. "+err.Error())
 		return
@@ -268,7 +308,7 @@ func (r *mongoResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	}
 
 	// Destroy instance
-	err = r.client.SimpleServiceDestroy(ctx, "mongo", state.ServiceName.ValueString())
+	err = client.SimpleServiceDestroy(ctx, "mongo", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to destroy service", "Unable to destroy service. "+err.Error())
 		return

--- a/provider/services/mysql_link_resource.go
+++ b/provider/services/mysql_link_resource.go
@@ -2,9 +2,11 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -28,7 +30,7 @@ func NewMysqlLinkResource() resource.Resource {
 }
 
 type mysqlLinkResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type mysqlLinkResourceModel struct {
@@ -42,14 +44,22 @@ func (r *mysqlLinkResource) Metadata(_ context.Context, req resource.MetadataReq
 	resp.TypeName = req.ProviderTypeName + "_mysql_link"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *mysqlLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *mysqlLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -100,8 +110,16 @@ func (r *mysqlLinkResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "mysql", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "mysql", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mysql service existence", "Unable to check mysql service existence. "+err.Error())
 		return
@@ -112,7 +130,7 @@ func (r *mysqlLinkResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "mysql", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "mysql", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mysql link existence", "Unable to check mysql link existence. "+err.Error())
 		return
@@ -140,8 +158,16 @@ func (r *mysqlLinkResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "mysql", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "mysql", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mysql service existence", "Unable to check mysql service existence. "+err.Error())
 		return
@@ -152,7 +178,7 @@ func (r *mysqlLinkResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "mysql", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "mysql", plan.ServiceName.ValueString(), plan.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mysql link existence", "Unable to check mysql link existence. "+err.Error())
 		return
@@ -168,7 +194,7 @@ func (r *mysqlLinkResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "mysql", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
+	err = client.SimpleServiceLinkCreate(ctx, "mysql", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create mysql link", "Unable to create mysql link. "+err.Error())
 		return
@@ -197,8 +223,16 @@ func (r *mysqlLinkResource) Delete(ctx context.Context, req resource.DeleteReque
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "mysql", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "mysql", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mysql service existence", "Unable to check mysql service existence. "+err.Error())
 		return
@@ -208,7 +242,7 @@ func (r *mysqlLinkResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "mysql", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "mysql", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mysql link existence", "Unable to check mysql link existence. "+err.Error())
 		return
@@ -218,7 +252,7 @@ func (r *mysqlLinkResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	// Unlink service
-	err = r.client.SimpleServiceLinkRemove(ctx, "mysql", state.ServiceName.ValueString(), state.AppName.ValueString())
+	err = client.SimpleServiceLinkRemove(ctx, "mysql", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to unlink service from app", "Unable to unlink service from app. "+err.Error())
 		return

--- a/provider/services/mysql_resource.go
+++ b/provider/services/mysql_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -29,7 +29,7 @@ func NewMysqlResource() resource.Resource {
 }
 
 type mysqlResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type mysqlResourceModel struct {
@@ -43,14 +43,22 @@ func (r *mysqlResource) Metadata(_ context.Context, req resource.MetadataRequest
 	resp.TypeName = req.ProviderTypeName + "_mysql"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *mysqlResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *mysqlResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -99,8 +107,16 @@ func (r *mysqlResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "mysql", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "mysql", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mysql service existence", "Unable to check mysql service existence. "+err.Error())
 		return
@@ -110,7 +126,7 @@ func (r *mysqlResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	info, err := r.client.SimpleServiceInfo(ctx, "mysql", state.ServiceName.ValueString())
+	info, err := client.SimpleServiceInfo(ctx, "mysql", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to get mysql service info", "Unable to get mysql service info. "+err.Error())
 		return
@@ -149,8 +165,16 @@ func (r *mysqlResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Create service is not exists
-	exists, err := r.client.SimpleServiceExists(ctx, "mysql", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "mysql", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mysql service existence", "Unable to check mysql service existence. "+err.Error())
 		return
@@ -172,14 +196,14 @@ func (r *mysqlResource) Create(ctx context.Context, req resource.CreateRequest, 
 		}
 	}
 
-	err = r.client.SimpleServiceCreate(ctx, "mysql", plan.ServiceName.ValueString())
+	err = client.SimpleServiceCreate(ctx, "mysql", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create mysql service", "Unable to create mysql service. "+err.Error())
 		return
 	}
 
 	if !plan.Expose.IsNull() {
-		err := r.client.SimpleServiceExpose(ctx, "mysql", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+		err := client.SimpleServiceExpose(ctx, "mysql", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to expose mysql service", "Unable to expose mysql service. "+err.Error())
 			return
@@ -210,26 +234,34 @@ func (r *mysqlResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	if plan.ServiceName.ValueString() != state.ServiceName.ValueString() {
 		resp.Diagnostics.AddError("service_name can't be changed", "service_name can't be changed")
 	}
 
 	if !plan.Expose.IsNull() {
 		if !plan.Expose.Equal(state.Expose) {
-			err := r.client.SimpleServiceUnexpose(ctx, "mysql", state.ServiceName.ValueString())
+			err := client.SimpleServiceUnexpose(ctx, "mysql", state.ServiceName.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to unexpose mysql service", "Unable to unexpose mysql service. "+err.Error())
 				return
 			}
 
-			err = r.client.SimpleServiceExpose(ctx, "mysql", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+			err = client.SimpleServiceExpose(ctx, "mysql", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to expose mysql service", "Unable to expose mysql service. "+err.Error())
 				return
 			}
 		}
 	} else if !state.Expose.IsNull() {
-		err := r.client.SimpleServiceUnexpose(ctx, "mysql", state.ServiceName.ValueString())
+		err := client.SimpleServiceUnexpose(ctx, "mysql", state.ServiceName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to unexpose mysql service", "Unable to unexpose mysql service. "+err.Error())
 			return
@@ -257,8 +289,16 @@ func (r *mysqlResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "mysql", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "mysql", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check mysql service existence", "Unable to check mysql service existence. "+err.Error())
 		return
@@ -268,7 +308,7 @@ func (r *mysqlResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	}
 
 	// Destroy instance
-	err = r.client.SimpleServiceDestroy(ctx, "mysql", state.ServiceName.ValueString())
+	err = client.SimpleServiceDestroy(ctx, "mysql", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to destroy service", "Unable to destroy service. "+err.Error())
 		return

--- a/provider/services/nats_link_resource.go
+++ b/provider/services/nats_link_resource.go
@@ -2,9 +2,11 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -28,7 +30,7 @@ func NewNatsLinkResource() resource.Resource {
 }
 
 type natsLinkResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type natsLinkResourceModel struct {
@@ -42,14 +44,22 @@ func (r *natsLinkResource) Metadata(_ context.Context, req resource.MetadataRequ
 	resp.TypeName = req.ProviderTypeName + "_nats_link"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *natsLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *natsLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -100,8 +110,16 @@ func (r *natsLinkResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "nats", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "nats", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check nats service existence", "Unable to check nats service existence. "+err.Error())
 		return
@@ -112,7 +130,7 @@ func (r *natsLinkResource) Read(ctx context.Context, req resource.ReadRequest, r
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "nats", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "nats", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check nats link existence", "Unable to check nats link existence. "+err.Error())
 		return
@@ -140,8 +158,16 @@ func (r *natsLinkResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "nats", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "nats", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check nats service existence", "Unable to check nats service existence. "+err.Error())
 		return
@@ -152,7 +178,7 @@ func (r *natsLinkResource) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "nats", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "nats", plan.ServiceName.ValueString(), plan.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check nats link existence", "Unable to check nats link existence. "+err.Error())
 		return
@@ -168,7 +194,7 @@ func (r *natsLinkResource) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "nats", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
+	err = client.SimpleServiceLinkCreate(ctx, "nats", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create nats link", "Unable to create nats link. "+err.Error())
 		return
@@ -197,8 +223,16 @@ func (r *natsLinkResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "nats", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "nats", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check nats service existence", "Unable to check nats service existence. "+err.Error())
 		return
@@ -208,7 +242,7 @@ func (r *natsLinkResource) Delete(ctx context.Context, req resource.DeleteReques
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "nats", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "nats", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check nats link existence", "Unable to check nats link existence. "+err.Error())
 		return
@@ -218,7 +252,7 @@ func (r *natsLinkResource) Delete(ctx context.Context, req resource.DeleteReques
 	}
 
 	// Unlink service
-	err = r.client.SimpleServiceLinkRemove(ctx, "nats", state.ServiceName.ValueString(), state.AppName.ValueString())
+	err = client.SimpleServiceLinkRemove(ctx, "nats", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to unlink service from app", "Unable to unlink service from app. "+err.Error())
 		return

--- a/provider/services/nats_resource.go
+++ b/provider/services/nats_resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -29,7 +30,7 @@ func NewNatsResource() resource.Resource {
 }
 
 type natsResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type natsResourceModel struct {
@@ -44,14 +45,22 @@ func (r *natsResource) Metadata(_ context.Context, req resource.MetadataRequest,
 	resp.TypeName = req.ProviderTypeName + "_nats"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *natsResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *natsResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -110,8 +119,16 @@ func (r *natsResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "nats", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "nats", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check nats service existence", "Unable to check nats service existence. "+err.Error())
 		return
@@ -121,7 +138,7 @@ func (r *natsResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	info, err := r.client.SimpleServiceInfo(ctx, "nats", state.ServiceName.ValueString())
+	info, err := client.SimpleServiceInfo(ctx, "nats", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to get nats service info", "Unable to get nats service info. "+err.Error())
 		return
@@ -165,8 +182,16 @@ func (r *natsResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Create service is not exists
-	exists, err := r.client.SimpleServiceExists(ctx, "nats", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "nats", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check nats service existence", "Unable to check nats service existence. "+err.Error())
 		return
@@ -192,14 +217,14 @@ func (r *natsResource) Create(ctx context.Context, req resource.CreateRequest, r
 		args = append(args, dokkuclient.DoubleDashArg("config-options", plan.ConfigOptions))
 	}
 
-	err = r.client.SimpleServiceCreate(ctx, "nats", plan.ServiceName.ValueString(), args...)
+	err = client.SimpleServiceCreate(ctx, "nats", plan.ServiceName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create nats service", "Unable to create nats service. "+err.Error())
 		return
 	}
 
 	if !plan.Expose.IsNull() {
-		err := r.client.SimpleServiceExpose(ctx, "nats", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+		err := client.SimpleServiceExpose(ctx, "nats", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to expose nats service", "Unable to expose nats service. "+err.Error())
 			return
@@ -207,7 +232,7 @@ func (r *natsResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	// Read the service info to populate computed fields like image
-	info, err := r.client.SimpleServiceInfo(ctx, "nats", plan.ServiceName.ValueString())
+	info, err := client.SimpleServiceInfo(ctx, "nats", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to get nats service info", "Unable to get nats service info. "+err.Error())
 		return
@@ -247,22 +272,30 @@ func (r *natsResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		resp.Diagnostics.AddError("service_name can't be changed", "service_name can't be changed")
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	if !plan.Expose.IsNull() {
 		if !plan.Expose.Equal(state.Expose) {
-			err := r.client.SimpleServiceUnexpose(ctx, "nats", state.ServiceName.ValueString())
+			err := client.SimpleServiceUnexpose(ctx, "nats", state.ServiceName.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to unexpose nats service", "Unable to unexpose nats service. "+err.Error())
 				return
 			}
 
-			err = r.client.SimpleServiceExpose(ctx, "nats", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+			err = client.SimpleServiceExpose(ctx, "nats", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to expose nats service", "Unable to expose nats service. "+err.Error())
 				return
 			}
 		}
 	} else if !state.Expose.IsNull() {
-		err := r.client.SimpleServiceUnexpose(ctx, "nats", state.ServiceName.ValueString())
+		err := client.SimpleServiceUnexpose(ctx, "nats", state.ServiceName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to unexpose nats service", "Unable to unexpose nats service. "+err.Error())
 			return
@@ -290,8 +323,16 @@ func (r *natsResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "nats", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "nats", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check nats service existence", "Unable to check nats service existence. "+err.Error())
 		return
@@ -301,7 +342,7 @@ func (r *natsResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	}
 
 	// Destroy instance
-	err = r.client.SimpleServiceDestroy(ctx, "nats", state.ServiceName.ValueString())
+	err = client.SimpleServiceDestroy(ctx, "nats", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to destroy service", "Unable to destroy service. "+err.Error())
 		return

--- a/provider/services/postgres_link_resource.go
+++ b/provider/services/postgres_link_resource.go
@@ -2,9 +2,11 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -28,7 +30,7 @@ func NewPostgresLinkResource() resource.Resource {
 }
 
 type postgresLinkResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type postgresLinkResourceModel struct {
@@ -42,14 +44,22 @@ func (r *postgresLinkResource) Metadata(_ context.Context, req resource.Metadata
 	resp.TypeName = req.ProviderTypeName + "_postgres_link"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *postgresLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *postgresLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -100,8 +110,16 @@ func (r *postgresLinkResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "postgres", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "postgres", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check postgres service existence", "Unable to check postgres service existence. "+err.Error())
 		return
@@ -112,7 +130,7 @@ func (r *postgresLinkResource) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "postgres", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "postgres", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check postgres link existence", "Unable to check postgres link existence. "+err.Error())
 		return
@@ -140,8 +158,16 @@ func (r *postgresLinkResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "postgres", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "postgres", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check postgres service existence", "Unable to check postgres service existence. "+err.Error())
 		return
@@ -152,7 +178,7 @@ func (r *postgresLinkResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "postgres", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "postgres", plan.ServiceName.ValueString(), plan.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check postgres link existence", "Unable to check postgres link existence. "+err.Error())
 		return
@@ -168,7 +194,7 @@ func (r *postgresLinkResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "postgres", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
+	err = client.SimpleServiceLinkCreate(ctx, "postgres", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create postgres link", "Unable to create postgres link. "+err.Error())
 		return
@@ -197,8 +223,16 @@ func (r *postgresLinkResource) Delete(ctx context.Context, req resource.DeleteRe
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "postgres", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "postgres", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check postgres service existence", "Unable to check postgres service existence. "+err.Error())
 		return
@@ -208,7 +242,7 @@ func (r *postgresLinkResource) Delete(ctx context.Context, req resource.DeleteRe
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "postgres", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "postgres", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check postgres link existence", "Unable to check postgres link existence. "+err.Error())
 		return
@@ -218,7 +252,7 @@ func (r *postgresLinkResource) Delete(ctx context.Context, req resource.DeleteRe
 	}
 
 	// Unlink service
-	err = r.client.SimpleServiceLinkRemove(ctx, "postgres", state.ServiceName.ValueString(), state.AppName.ValueString())
+	err = client.SimpleServiceLinkRemove(ctx, "postgres", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to unlink service from app", "Unable to unlink service from app. "+err.Error())
 		return

--- a/provider/services/postgres_resource.go
+++ b/provider/services/postgres_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -29,7 +29,7 @@ func NewPostgresResource() resource.Resource {
 }
 
 type postgresResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type postgresResourceModel struct {
@@ -43,14 +43,22 @@ func (r *postgresResource) Metadata(_ context.Context, req resource.MetadataRequ
 	resp.TypeName = req.ProviderTypeName + "_postgres"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *postgresResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *postgresResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -99,8 +107,16 @@ func (r *postgresResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "postgres", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "postgres", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check postgres service existence", "Unable to check postgres service existence. "+err.Error())
 		return
@@ -110,7 +126,7 @@ func (r *postgresResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	info, err := r.client.SimpleServiceInfo(ctx, "postgres", state.ServiceName.ValueString())
+	info, err := client.SimpleServiceInfo(ctx, "postgres", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to get postgres service info", "Unable to get postgres service info. "+err.Error())
 		return
@@ -149,8 +165,16 @@ func (r *postgresResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Create service is not exists
-	exists, err := r.client.SimpleServiceExists(ctx, "postgres", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "postgres", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check postgres service existence", "Unable to check postgres service existence. "+err.Error())
 		return
@@ -172,14 +196,14 @@ func (r *postgresResource) Create(ctx context.Context, req resource.CreateReques
 		}
 	}
 
-	err = r.client.SimpleServiceCreate(ctx, "postgres", plan.ServiceName.ValueString(), args...)
+	err = client.SimpleServiceCreate(ctx, "postgres", plan.ServiceName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create postgres service", "Unable to create postgres service. "+err.Error())
 		return
 	}
 
 	if !plan.Expose.IsNull() {
-		err := r.client.SimpleServiceExpose(ctx, "postgres", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+		err := client.SimpleServiceExpose(ctx, "postgres", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to expose postgres service", "Unable to expose postgres service. "+err.Error())
 			return
@@ -210,26 +234,34 @@ func (r *postgresResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	if plan.ServiceName.ValueString() != state.ServiceName.ValueString() {
 		resp.Diagnostics.AddError("service_name can't be changed", "service_name can't be changed")
 	}
 
 	if !plan.Expose.IsNull() {
 		if !plan.Expose.Equal(state.Expose) {
-			err := r.client.SimpleServiceUnexpose(ctx, "postgres", state.ServiceName.ValueString())
+			err := client.SimpleServiceUnexpose(ctx, "postgres", state.ServiceName.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to unexpose postgres service", "Unable to unexpose postgres service. "+err.Error())
 				return
 			}
 
-			err = r.client.SimpleServiceExpose(ctx, "postgres", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+			err = client.SimpleServiceExpose(ctx, "postgres", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to expose postgres service", "Unable to expose postgres service. "+err.Error())
 				return
 			}
 		}
 	} else if !state.Expose.IsNull() {
-		err := r.client.SimpleServiceUnexpose(ctx, "postgres", state.ServiceName.ValueString())
+		err := client.SimpleServiceUnexpose(ctx, "postgres", state.ServiceName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to unexpose postgres service", "Unable to unexpose postgres service. "+err.Error())
 			return
@@ -257,8 +289,16 @@ func (r *postgresResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "postgres", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "postgres", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check postgres service existence", "Unable to check postgres service existence. "+err.Error())
 		return
@@ -268,7 +308,7 @@ func (r *postgresResource) Delete(ctx context.Context, req resource.DeleteReques
 	}
 
 	// Destroy instance
-	err = r.client.SimpleServiceDestroy(ctx, "postgres", state.ServiceName.ValueString())
+	err = client.SimpleServiceDestroy(ctx, "postgres", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to destroy service", "Unable to destroy service. "+err.Error())
 		return

--- a/provider/services/rabbitmq_link_resource.go
+++ b/provider/services/rabbitmq_link_resource.go
@@ -2,9 +2,11 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -28,7 +30,7 @@ func NewRabbitMQLinkResource() resource.Resource {
 }
 
 type rabbitMQLinkResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type rabbitMQLinkResourceModel struct {
@@ -42,14 +44,22 @@ func (r *rabbitMQLinkResource) Metadata(_ context.Context, req resource.Metadata
 	resp.TypeName = req.ProviderTypeName + "_rabbitmq_link"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *rabbitMQLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *rabbitMQLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -100,8 +110,16 @@ func (r *rabbitMQLinkResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "rabbitmq", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "rabbitmq", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check rabbitMQ service existence", "Unable to check rabbitMQ service existence. "+err.Error())
 		return
@@ -112,7 +130,7 @@ func (r *rabbitMQLinkResource) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "rabbitmq", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "rabbitmq", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check rabbitMQ link existence", "Unable to check rabbitMQ link existence. "+err.Error())
 		return
@@ -140,8 +158,16 @@ func (r *rabbitMQLinkResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "rabbitmq", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "rabbitmq", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check rabbitMQ service existence", "Unable to check rabbitMQ service existence. "+err.Error())
 		return
@@ -152,7 +178,7 @@ func (r *rabbitMQLinkResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "rabbitmq", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "rabbitmq", plan.ServiceName.ValueString(), plan.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check rabbitMQ link existence", "Unable to check rabbitMQ link existence. "+err.Error())
 		return
@@ -168,7 +194,7 @@ func (r *rabbitMQLinkResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "rabbitmq", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
+	err = client.SimpleServiceLinkCreate(ctx, "rabbitmq", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create rabbitMQ link", "Unable to create rabbitMQ link. "+err.Error())
 		return
@@ -197,8 +223,16 @@ func (r *rabbitMQLinkResource) Delete(ctx context.Context, req resource.DeleteRe
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "rabbitmq", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "rabbitmq", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check rabbitMQ service existence", "Unable to check rabbitMQ service existence. "+err.Error())
 		return
@@ -208,7 +242,7 @@ func (r *rabbitMQLinkResource) Delete(ctx context.Context, req resource.DeleteRe
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "rabbitmq", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "rabbitmq", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check rabbitMQ link existence", "Unable to check rabbitMQ link existence. "+err.Error())
 		return
@@ -218,7 +252,7 @@ func (r *rabbitMQLinkResource) Delete(ctx context.Context, req resource.DeleteRe
 	}
 
 	// Unlink service
-	err = r.client.SimpleServiceLinkRemove(ctx, "rabbitmq", state.ServiceName.ValueString(), state.AppName.ValueString())
+	err = client.SimpleServiceLinkRemove(ctx, "rabbitmq", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to unlink service from app", "Unable to unlink service from app. "+err.Error())
 		return

--- a/provider/services/rabbitmq_resource.go
+++ b/provider/services/rabbitmq_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -29,7 +29,7 @@ func NewRabbitMQResource() resource.Resource {
 }
 
 type rabbitMQResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type rabbitMQResourceModel struct {
@@ -43,14 +43,22 @@ func (r *rabbitMQResource) Metadata(_ context.Context, req resource.MetadataRequ
 	resp.TypeName = req.ProviderTypeName + "_rabbitmq"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *rabbitMQResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *rabbitMQResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -99,8 +107,16 @@ func (r *rabbitMQResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "rabbitmq", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "rabbitmq", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check rabbitMQ service existence", "Unable to check rabbitMQ service existence. "+err.Error())
 		return
@@ -110,7 +126,7 @@ func (r *rabbitMQResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	info, err := r.client.SimpleServiceInfo(ctx, "rabbitmq", state.ServiceName.ValueString())
+	info, err := client.SimpleServiceInfo(ctx, "rabbitmq", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to get rabbitmq service info", "Unable to get rabbitmq service info. "+err.Error())
 		return
@@ -149,8 +165,16 @@ func (r *rabbitMQResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Create service is not exists
-	exists, err := r.client.SimpleServiceExists(ctx, "rabbitmq", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "rabbitmq", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check rabbitMQ service existence", "Unable to check rabbitMQ service existence. "+err.Error())
 		return
@@ -172,14 +196,14 @@ func (r *rabbitMQResource) Create(ctx context.Context, req resource.CreateReques
 		}
 	}
 
-	err = r.client.SimpleServiceCreate(ctx, "rabbitmq", plan.ServiceName.ValueString())
+	err = client.SimpleServiceCreate(ctx, "rabbitmq", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create rabbitMQ service", "Unable to create rabbitMQ service. "+err.Error())
 		return
 	}
 
 	if !plan.Expose.IsNull() {
-		err := r.client.SimpleServiceExpose(ctx, "rabbitmq", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+		err := client.SimpleServiceExpose(ctx, "rabbitmq", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to expose rabbitmq service", "Unable to expose rabbitmq service. "+err.Error())
 			return
@@ -214,22 +238,30 @@ func (r *rabbitMQResource) Update(ctx context.Context, req resource.UpdateReques
 		resp.Diagnostics.AddError("service_name can't be changed", "service_name can't be changed")
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	if !plan.Expose.IsNull() {
 		if !plan.Expose.Equal(state.Expose) {
-			err := r.client.SimpleServiceUnexpose(ctx, "rabbitmq", state.ServiceName.ValueString())
+			err := client.SimpleServiceUnexpose(ctx, "rabbitmq", state.ServiceName.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to unexpose rabbitmq service", "Unable to unexpose rabbitmq service. "+err.Error())
 				return
 			}
 
-			err = r.client.SimpleServiceExpose(ctx, "rabbitmq", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+			err = client.SimpleServiceExpose(ctx, "rabbitmq", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to expose rabbitmq service", "Unable to expose rabbitmq service. "+err.Error())
 				return
 			}
 		}
 	} else if !state.Expose.IsNull() {
-		err := r.client.SimpleServiceUnexpose(ctx, "rabbitmq", state.ServiceName.ValueString())
+		err := client.SimpleServiceUnexpose(ctx, "rabbitmq", state.ServiceName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to unexpose rabbitmq service", "Unable to unexpose rabbitmq service. "+err.Error())
 			return
@@ -257,8 +289,16 @@ func (r *rabbitMQResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "rabbitmq", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "rabbitmq", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check rabbitMQ service existence", "Unable to check rabbitMQ service existence. "+err.Error())
 		return
@@ -268,7 +308,7 @@ func (r *rabbitMQResource) Delete(ctx context.Context, req resource.DeleteReques
 	}
 
 	// Destroy instance
-	err = r.client.SimpleServiceDestroy(ctx, "rabbitmq", state.ServiceName.ValueString())
+	err = client.SimpleServiceDestroy(ctx, "rabbitmq", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to destroy service", "Unable to destroy service. "+err.Error())
 		return

--- a/provider/services/redis_link_resource.go
+++ b/provider/services/redis_link_resource.go
@@ -2,9 +2,11 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -28,7 +30,7 @@ func NewRedisLinkResource() resource.Resource {
 }
 
 type redisLinkResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type redisLinkResourceModel struct {
@@ -42,14 +44,22 @@ func (r *redisLinkResource) Metadata(_ context.Context, req resource.MetadataReq
 	resp.TypeName = req.ProviderTypeName + "_redis_link"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *redisLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *redisLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -100,8 +110,16 @@ func (r *redisLinkResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "redis", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "redis", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check redis service existence", "Unable to check redis service existence. "+err.Error())
 		return
@@ -112,7 +130,7 @@ func (r *redisLinkResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "redis", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "redis", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check redis link existence", "Unable to check redis link existence. "+err.Error())
 		return
@@ -140,8 +158,16 @@ func (r *redisLinkResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "redis", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "redis", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check redis service existence", "Unable to check redis service existence. "+err.Error())
 		return
@@ -152,7 +178,7 @@ func (r *redisLinkResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "redis", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "redis", plan.ServiceName.ValueString(), plan.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check redis link existence", "Unable to check redis link existence. "+err.Error())
 		return
@@ -168,7 +194,7 @@ func (r *redisLinkResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "redis", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
+	err = client.SimpleServiceLinkCreate(ctx, "redis", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create redis link", "Unable to create redis link. "+err.Error())
 		return
@@ -197,8 +223,16 @@ func (r *redisLinkResource) Delete(ctx context.Context, req resource.DeleteReque
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "redis", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "redis", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check redis service existence", "Unable to check redis service existence. "+err.Error())
 		return
@@ -208,7 +242,7 @@ func (r *redisLinkResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "redis", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "redis", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check redis link existence", "Unable to check redis link existence. "+err.Error())
 		return
@@ -218,7 +252,7 @@ func (r *redisLinkResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	// Unlink service
-	err = r.client.SimpleServiceLinkRemove(ctx, "redis", state.ServiceName.ValueString(), state.AppName.ValueString())
+	err = client.SimpleServiceLinkRemove(ctx, "redis", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to unlink service from app", "Unable to unlink service from app. "+err.Error())
 		return

--- a/provider/services/redis_resource.go
+++ b/provider/services/redis_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -29,7 +29,7 @@ func NewRedisResource() resource.Resource {
 }
 
 type redisResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type redisResourceModel struct {
@@ -43,14 +43,22 @@ func (r *redisResource) Metadata(_ context.Context, req resource.MetadataRequest
 	resp.TypeName = req.ProviderTypeName + "_redis"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *redisResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *redisResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -99,8 +107,16 @@ func (r *redisResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "redis", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "redis", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check redis service existence", "Unable to check redis service existence. "+err.Error())
 		return
@@ -110,7 +126,7 @@ func (r *redisResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	info, err := r.client.SimpleServiceInfo(ctx, "redis", state.ServiceName.ValueString())
+	info, err := client.SimpleServiceInfo(ctx, "redis", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to get redis service info", "Unable to get redis service info. "+err.Error())
 		return
@@ -149,8 +165,16 @@ func (r *redisResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Create service is not exists
-	exists, err := r.client.SimpleServiceExists(ctx, "redis", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "redis", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check redis service existence", "Unable to check redis service existence. "+err.Error())
 		return
@@ -172,14 +196,14 @@ func (r *redisResource) Create(ctx context.Context, req resource.CreateRequest, 
 		}
 	}
 
-	err = r.client.SimpleServiceCreate(ctx, "redis", plan.ServiceName.ValueString(), args...)
+	err = client.SimpleServiceCreate(ctx, "redis", plan.ServiceName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create redis service", "Unable to create redis service. "+err.Error())
 		return
 	}
 
 	if !plan.Expose.IsNull() {
-		err := r.client.SimpleServiceExpose(ctx, "redis", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+		err := client.SimpleServiceExpose(ctx, "redis", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to expose redis service", "Unable to expose redis service. "+err.Error())
 			return
@@ -210,26 +234,34 @@ func (r *redisResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	if plan.ServiceName.ValueString() != state.ServiceName.ValueString() {
 		resp.Diagnostics.AddError("service_name can't be changed", "service_name can't be changed")
 	}
 
 	if !plan.Expose.IsNull() {
 		if !plan.Expose.Equal(state.Expose) {
-			err := r.client.SimpleServiceUnexpose(ctx, "redis", state.ServiceName.ValueString())
+			err := client.SimpleServiceUnexpose(ctx, "redis", state.ServiceName.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to unexpose redis service", "Unable to unexpose redis service. "+err.Error())
 				return
 			}
 
-			err = r.client.SimpleServiceExpose(ctx, "redis", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+			err = client.SimpleServiceExpose(ctx, "redis", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to expose redis service", "Unable to expose redis service. "+err.Error())
 				return
 			}
 		}
 	} else if !state.Expose.IsNull() {
-		err := r.client.SimpleServiceUnexpose(ctx, "redis", state.ServiceName.ValueString())
+		err := client.SimpleServiceUnexpose(ctx, "redis", state.ServiceName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to unexpose redis service", "Unable to unexpose redis service. "+err.Error())
 			return
@@ -257,8 +289,16 @@ func (r *redisResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "redis", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "redis", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check redis service existence", "Unable to check redis service existence. "+err.Error())
 		return
@@ -268,7 +308,7 @@ func (r *redisResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	}
 
 	// Destroy instance
-	err = r.client.SimpleServiceDestroy(ctx, "redis", state.ServiceName.ValueString())
+	err = client.SimpleServiceDestroy(ctx, "redis", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to destroy service", "Unable to destroy service. "+err.Error())
 		return

--- a/provider/services/rethinkdb_link_resource.go
+++ b/provider/services/rethinkdb_link_resource.go
@@ -2,9 +2,11 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -28,7 +30,7 @@ func NewRethinkDBLinkResource() resource.Resource {
 }
 
 type rethinkDBLinkResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type rethinkDBLinkResourceModel struct {
@@ -42,14 +44,22 @@ func (r *rethinkDBLinkResource) Metadata(_ context.Context, req resource.Metadat
 	resp.TypeName = req.ProviderTypeName + "_rethinkdb_link"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *rethinkDBLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *rethinkDBLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -100,8 +110,16 @@ func (r *rethinkDBLinkResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "rethinkdb", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "rethinkdb", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check rethinkDB service existence", "Unable to check rethinkDB service existence. "+err.Error())
 		return
@@ -112,7 +130,7 @@ func (r *rethinkDBLinkResource) Read(ctx context.Context, req resource.ReadReque
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "rethinkdb", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "rethinkdb", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check rethinkDB link existence", "Unable to check rethinkDB link existence. "+err.Error())
 		return
@@ -140,8 +158,16 @@ func (r *rethinkDBLinkResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "rethinkdb", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "rethinkdb", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check rethinkDB service existence", "Unable to check rethinkDB service existence. "+err.Error())
 		return
@@ -152,7 +178,7 @@ func (r *rethinkDBLinkResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "rethinkdb", plan.ServiceName.ValueString(), plan.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "rethinkdb", plan.ServiceName.ValueString(), plan.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check rethinkDB link existence", "Unable to check rethinkDB link existence. "+err.Error())
 		return
@@ -168,7 +194,7 @@ func (r *rethinkDBLinkResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	// Create link
-	err = r.client.SimpleServiceLinkCreate(ctx, "rethinkdb", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
+	err = client.SimpleServiceLinkCreate(ctx, "rethinkdb", plan.ServiceName.ValueString(), plan.AppName.ValueString(), args...)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create rethinkDB link", "Unable to create rethinkDB link. "+err.Error())
 		return
@@ -197,8 +223,16 @@ func (r *rethinkDBLinkResource) Delete(ctx context.Context, req resource.DeleteR
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "rethinkdb", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "rethinkdb", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check rethinkDB service existence", "Unable to check rethinkDB service existence. "+err.Error())
 		return
@@ -208,7 +242,7 @@ func (r *rethinkDBLinkResource) Delete(ctx context.Context, req resource.DeleteR
 	}
 
 	// Check link existence
-	exists, err = r.client.SimpleServiceLinkExists(ctx, "rethinkdb", state.ServiceName.ValueString(), state.AppName.ValueString())
+	exists, err = client.SimpleServiceLinkExists(ctx, "rethinkdb", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check rethinkDB link existence", "Unable to check rethinkDB link existence. "+err.Error())
 		return
@@ -218,7 +252,7 @@ func (r *rethinkDBLinkResource) Delete(ctx context.Context, req resource.DeleteR
 	}
 
 	// Unlink service
-	err = r.client.SimpleServiceLinkRemove(ctx, "rethinkdb", state.ServiceName.ValueString(), state.AppName.ValueString())
+	err = client.SimpleServiceLinkRemove(ctx, "rethinkdb", state.ServiceName.ValueString(), state.AppName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to unlink service from app", "Unable to unlink service from app. "+err.Error())
 		return

--- a/provider/services/rethinkdb_resource.go
+++ b/provider/services/rethinkdb_resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	dokkuclient "github.com/aliksend/terraform-provider-dokku/provider/dokku_client"
+	"github.com/aliksend/terraform-provider-dokku/internal/config"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -29,7 +29,7 @@ func NewRethinkDBResource() resource.Resource {
 }
 
 type rethinkDBResource struct {
-	client *dokkuclient.Client
+	config *config.DokkuConfig
 }
 
 type rethinkDBResourceModel struct {
@@ -43,14 +43,22 @@ func (r *rethinkDBResource) Metadata(_ context.Context, req resource.MetadataReq
 	resp.TypeName = req.ProviderTypeName + "_rethinkdb"
 }
 
-// Configure adds the provider configured client to the resource.
-func (r *rethinkDBResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+// Configure adds the provider configured config to the resource.
+func (r *rethinkDBResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	//nolint:forcetypeassert
-	r.client = req.ProviderData.(*dokkuclient.Client)
+	config, ok := req.ProviderData.(*config.DokkuConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *config.DokkuConfig, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
 }
 
 // Schema defines the schema for the resource.
@@ -99,8 +107,16 @@ func (r *rethinkDBResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "rethinkdb", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "rethinkdb", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check rethinkDB service existence", "Unable to check rethinkDB service existence. "+err.Error())
 		return
@@ -110,7 +126,7 @@ func (r *rethinkDBResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	info, err := r.client.SimpleServiceInfo(ctx, "rethinkdb", state.ServiceName.ValueString())
+	info, err := client.SimpleServiceInfo(ctx, "rethinkdb", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to get rethinkdb service info", "Unable to get rethinkdb service info. "+err.Error())
 		return
@@ -149,8 +165,16 @@ func (r *rethinkDBResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Create service is not exists
-	exists, err := r.client.SimpleServiceExists(ctx, "rethinkdb", plan.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "rethinkdb", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check rethinkDB service existence", "Unable to check rethinkDB service existence. "+err.Error())
 		return
@@ -172,14 +196,14 @@ func (r *rethinkDBResource) Create(ctx context.Context, req resource.CreateReque
 		}
 	}
 
-	err = r.client.SimpleServiceCreate(ctx, "rethinkdb", plan.ServiceName.ValueString())
+	err = client.SimpleServiceCreate(ctx, "rethinkdb", plan.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create rethinkDB service", "Unable to create rethinkDB service. "+err.Error())
 		return
 	}
 
 	if !plan.Expose.IsNull() {
-		err := r.client.SimpleServiceExpose(ctx, "rethinkdb", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+		err := client.SimpleServiceExpose(ctx, "rethinkdb", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to expose rethinkdb service", "Unable to expose rethinkdb service. "+err.Error())
 			return
@@ -214,22 +238,30 @@ func (r *rethinkDBResource) Update(ctx context.Context, req resource.UpdateReque
 		resp.Diagnostics.AddError("service_name can't be changed", "service_name can't be changed")
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	if !plan.Expose.IsNull() {
 		if !plan.Expose.Equal(state.Expose) {
-			err := r.client.SimpleServiceUnexpose(ctx, "rethinkdb", state.ServiceName.ValueString())
+			err := client.SimpleServiceUnexpose(ctx, "rethinkdb", state.ServiceName.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to unexpose rethinkdb service", "Unable to unexpose rethinkdb service. "+err.Error())
 				return
 			}
 
-			err = r.client.SimpleServiceExpose(ctx, "rethinkdb", plan.ServiceName.ValueString(), plan.Expose.ValueString())
+			err = client.SimpleServiceExpose(ctx, "rethinkdb", plan.ServiceName.ValueString(), plan.Expose.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Unable to expose rethinkdb service", "Unable to expose rethinkdb service. "+err.Error())
 				return
 			}
 		}
 	} else if !state.Expose.IsNull() {
-		err := r.client.SimpleServiceUnexpose(ctx, "rethinkdb", state.ServiceName.ValueString())
+		err := client.SimpleServiceUnexpose(ctx, "rethinkdb", state.ServiceName.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Unable to unexpose rethinkdb service", "Unable to unexpose rethinkdb service. "+err.Error())
 			return
@@ -257,8 +289,16 @@ func (r *rethinkDBResource) Delete(ctx context.Context, req resource.DeleteReque
 		return
 	}
 
+	// Create SSH connection on-demand
+	client, err := r.config.NewClient(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("SSH connection failed", err.Error())
+		return
+	}
+	defer r.config.CloseClient(client)
+
 	// Check service existence
-	exists, err := r.client.SimpleServiceExists(ctx, "rethinkdb", state.ServiceName.ValueString())
+	exists, err := client.SimpleServiceExists(ctx, "rethinkdb", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to check rethinkDB service existence", "Unable to check rethinkDB service existence. "+err.Error())
 		return
@@ -268,7 +308,7 @@ func (r *rethinkDBResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	// Destroy instance
-	err = r.client.SimpleServiceDestroy(ctx, "rethinkdb", state.ServiceName.ValueString())
+	err = client.SimpleServiceDestroy(ctx, "rethinkdb", state.ServiceName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to destroy service", "Unable to destroy service. "+err.Error())
 		return

--- a/test/complex_app_config_test.go
+++ b/test/complex_app_config_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -15,7 +16,7 @@ import (
 )
 
 func TestComplexAppConfig(t *testing.T) {
-	// Removed t.Parallel() due to Docker container name conflicts
+	t.Parallel()
 	// This test uses properly typed variables with Terraform merge() function and validates
 	// that provider handles complex HCL types correctly and sets expected environment variables
 
@@ -23,18 +24,25 @@ func TestComplexAppConfig(t *testing.T) {
 	sourceDir := filepath.Join("test", "complex_app_config")
 	testDir := test_structure.CopyTerraformFolderToTemp(t, "../", sourceDir)
 
-	// Generate SSH keys first
-	var sshKeys *testSSHKeys
+	// Create isolated test environment
+	var env *testEnvironment
 	test_structure.RunTestStage(t, "generate_ssh_keys", func() {
-		sshKeys = generateSSHKeys(t, testDir)
+		env = createTestEnvironment(t, testDir)
 	})
 
+	// Ensure cleanup runs regardless of test outcome
+	defer func() {
+		if env != nil {
+			cleanupTestEnvironment(t, env)
+		}
+	}()
+
 	test_structure.RunTestStage(t, "setup_docker", func() {
-		setupDokkuContainer(t)
+		setupDokkuContainer(t, env)
 	})
 
 	test_structure.RunTestStage(t, "setup_ssh", func() {
-		setupSSH(t, sshKeys)
+		setupSSH(t, env)
 	})
 
 	test_structure.RunTestStage(t, "apply_terraform", func() {
@@ -46,11 +54,14 @@ func TestComplexAppConfig(t *testing.T) {
 		// Define test-specific configuration inline
 		appName := "complex-test-app"
 
-		// Base terraform options
+		// Base terraform options using environment-specific settings
+		sshPort, err := strconv.Atoi(env.ExternalPorts["ssh"])
+		require.NoError(t, err, "Failed to parse SSH port")
+
 		vars := map[string]interface{}{
 			"dokku_host":      "localhost",
-			"dokku_port":      3022,
-			"ssh_private_key": sshKeys.privateKeyPEM,
+			"dokku_port":      sshPort,
+			"ssh_private_key": env.SSHKeys.privateKeyPEM,
 			"app_name":        appName,
 			"app_config": map[string]interface{}{
 				"ENV":      "prod",
@@ -134,15 +145,19 @@ func TestComplexAppConfig(t *testing.T) {
 		appName := "complex-test-app"
 
 		keyPair := &ssh.KeyPair{
-			PublicKey:  sshKeys.publicKeySSH,
-			PrivateKey: sshKeys.privateKeyPEM,
+			PublicKey:  env.SSHKeys.publicKeySSH,
+			PrivateKey: env.SSHKeys.privateKeyPEM,
 		}
+
+		// Convert external port string to int
+		customPort, err := strconv.Atoi(env.ExternalPorts["ssh"])
+		require.NoError(t, err, "Failed to parse SSH port")
 
 		host := ssh.Host{
 			Hostname:    "localhost",
 			SshKeyPair:  keyPair,
 			SshUserName: "dokku",
-			CustomPort:  3022,
+			CustomPort:  customPort,
 		}
 
 		// Test SSH connection first with a retry mechanism
@@ -257,7 +272,6 @@ func TestComplexAppConfig(t *testing.T) {
 		}
 	})
 
-	test_structure.RunTestStage(t, "cleanup_docker", func() {
-		cleanupDocker(t)
-	})
+	// Note: Final cleanup is handled by the defer statement at the beginning
+	// which calls cleanupTestEnvironment(t, env)
 }

--- a/test/examples_dokku_app_test.go
+++ b/test/examples_dokku_app_test.go
@@ -1,214 +1,47 @@
 package test
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/gruntwork-io/terratest/modules/docker"
 	"github.com/gruntwork-io/terratest/modules/ssh"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	cryptossh "golang.org/x/crypto/ssh"
 )
 
 func TestExampleDokkuApp(t *testing.T) {
+	t.Parallel()
+
 	// Copy the dokku_app example directory first
 	testDir := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/resources/dokku_app")
 
-	// Generate SSH keys first
-	var sshKeys *testSSHKeys
+	// Create isolated test environment
+	var env *testEnvironment
 	test_structure.RunTestStage(t, "generate_ssh_keys", func() {
-		// Generate RSA private key
-		privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-		require.NoError(t, err, "Failed to generate private key")
-
-		// Encode private key to PEM format
-		privateKeyPEM := &pem.Block{
-			Type:  "RSA PRIVATE KEY",
-			Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
-		}
-		privateKeyBytes := pem.EncodeToMemory(privateKeyPEM)
-
-		// Generate public key in SSH format
-		publicKey, err := cryptossh.NewPublicKey(&privateKey.PublicKey)
-		require.NoError(t, err, "Failed to generate public key")
-		publicKeySSH := string(cryptossh.MarshalAuthorizedKey(publicKey))
-
-		// Write keys to files
-		privateKeyPath := filepath.Join(testDir, "ssh_key")
-		publicKeyPath := filepath.Join(testDir, "ssh_key.pub")
-
-		err = os.WriteFile(privateKeyPath, privateKeyBytes, 0600)
-		require.NoError(t, err, "Failed to write private key")
-
-		err = os.WriteFile(publicKeyPath, []byte(publicKeySSH), 0644)
-		require.NoError(t, err, "Failed to write public key")
-
-		t.Logf("Generated SSH keys: %s, %s", privateKeyPath, publicKeyPath)
-
-		sshKeys = &testSSHKeys{
-			privateKeyPEM:  string(privateKeyBytes),
-			publicKeySSH:   strings.TrimSpace(publicKeySSH),
-			privateKeyPath: privateKeyPath,
-			publicKeyPath:  publicKeyPath,
-		}
+		env = createTestEnvironment(t, testDir)
 	})
 
+	// Ensure cleanup runs regardless of test outcome
+	defer func() {
+		if env != nil {
+			cleanupTestEnvironment(t, env)
+		}
+	}()
+
 	test_structure.RunTestStage(t, "setup_docker", func() {
-		// Try to remove any existing container with the same name
-		cleanupCmd := exec.Command("docker", "rm", "-f", containerName)
-		cleanupCmd.Run()
-
-		// Get the Dokku version to use
-		dokkuVersion := getDokkuVersion()
-		dokkuImageName := fmt.Sprintf("dokku/dokku:%s", dokkuVersion)
-
-		// Run the Dokku container
-		runOptions := &docker.RunOptions{
-			Name:       containerName,
-			Detach:     true,
-			Privileged: true,
-			OtherOptions: []string{
-				"-p", fmt.Sprintf("%s:22", sshPort),
-				"-p", fmt.Sprintf("%s:80", httpPort),
-				"-e", "DOKKU_HOSTNAME=dokku.test",
-				"-e", "DOKKU_HOST_ROOT=/home/dokku/dokku",
-				"-v", "/var/run/docker.sock:/var/run/docker.sock",
-				"--add-host", "host.docker.internal:host-gateway",
-			},
-		}
-
-		docker.Run(t, dokkuImageName, runOptions)
-
-		// Wait for container to be up and running
-		retries := 30
-		retryInterval := 3 * time.Second
-		sshServiceRunning := false
-
-		for i := 0; i < retries; i++ {
-			// Check if SSH is running inside the container
-			sshCheckCmd := exec.Command("docker", "exec", containerName, "service", "ssh", "status")
-			err := sshCheckCmd.Run()
-			if err == nil {
-				sshServiceRunning = true
-				break
-			}
-			time.Sleep(retryInterval)
-		}
-
-		// Ensure dokku is installed and working
-		dokkuInstalled := false
-		if sshServiceRunning {
-			// Check if dokku command works
-			dokkuCheckCmd := exec.Command("docker", "exec", containerName, "dokku", "--version")
-			err := dokkuCheckCmd.Run()
-			if err == nil {
-				dokkuInstalled = true
-			}
-		}
-
-		// Configure sudo to not require a password for the dokku user
-		sudoersCmd := exec.Command("docker", "exec", containerName, "bash", "-c", "echo 'dokku ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/dokku")
-		sudoersOutput, err := sudoersCmd.CombinedOutput()
-		require.NoError(t, err, "Failed to configure sudoers: %s", string(sudoersOutput))
-
-		require.True(t, sshServiceRunning && dokkuInstalled, "Dokku container is not ready")
-		t.Logf("Container ready, waiting additional 15 seconds for services to fully stabilize...")
-		time.Sleep(15 * time.Second)
+		setupDokkuContainer(t, env)
 	})
 
 	test_structure.RunTestStage(t, "setup_ssh", func() {
-		// Use the generated SSH keys
-		pubKey := sshKeys.publicKeySSH
-		privateKeyPath := sshKeys.privateKeyPath
-
-		// Fix permissions on private key first
-		exec.Command("chmod", "600", privateKeyPath).Run()
-
-		// Use a correct forced command format that works with dokku
-		authorizedKeyEntry := fmt.Sprintf(`command="dokku $SSH_ORIGINAL_COMMAND",no-port-forwarding,no-agent-forwarding %s dokku-test-key`, pubKey)
-
-		// Multiple attempts to set up SSH properly
-		for attempt := 0; attempt < 3; attempt++ {
-			// Configure SSH key in the container with more thorough setup
-			setupCmd := exec.Command("docker", "exec", containerName, "bash", "-c", fmt.Sprintf(`
-				# Ensure dokku user exists
-				id dokku || exit 1
-				
-				# Create .ssh directory with proper permissions
-				mkdir -p /home/dokku/.ssh
-				chmod 700 /home/dokku/.ssh
-				
-				# Add the SSH key
-				echo '%s' > /home/dokku/.ssh/authorized_keys
-				chmod 600 /home/dokku/.ssh/authorized_keys
-				chown -R dokku:dokku /home/dokku/.ssh
-				
-				# Ensure SSH daemon is running
-				service ssh start || service sshd start
-				sleep 2
-				
-				# Test that SSH service is listening
-				netstat -tlnp | grep :22 || ss -tlnp | grep :22
-			`, authorizedKeyEntry))
-
-			output, err := setupCmd.CombinedOutput()
-			t.Logf("SSH setup attempt %d output: %s", attempt+1, string(output))
-
-			if err == nil {
-				break
-			}
-
-			if attempt == 2 {
-				t.Logf("SSH setup failed after 3 attempts: %v", err)
-			}
-			time.Sleep(2 * time.Second)
-		}
-
-		// Give SSH service more time to fully start
-		time.Sleep(5 * time.Second)
-
-		// Verify SSH connectivity with the dokku version command
-		maxRetries := 5
-		retryDelay := 3 * time.Second
-
-		for i := 0; i < maxRetries; i++ {
-			sshCmd := exec.Command("ssh", "-F", "/dev/null", // Bypass user SSH config
-				"-i", privateKeyPath,
-				"-p", sshPort,
-				"-o", "StrictHostKeyChecking=no",
-				"-o", "UserKnownHostsFile=/dev/null",
-				"-o", "ConnectTimeout=10",
-				"-o", "LogLevel=ERROR",
-				"dokku@localhost",
-				"version")
-
-			output, err := sshCmd.CombinedOutput()
-			t.Logf("SSH test attempt %d: %v, output: %s", i+1, err, string(output))
-
-			if err == nil {
-				t.Logf("SSH connection successful!")
-				return
-			}
-
-			if i < maxRetries-1 {
-				t.Logf("SSH connection failed, retrying in %v...", retryDelay)
-				time.Sleep(retryDelay)
-			}
-		}
-
-		require.Fail(t, "Failed to establish SSH connection after %d retries", maxRetries)
+		setupSSH(t, env)
 	})
 
 	test_structure.RunTestStage(t, "apply_terraform", func() {
@@ -273,11 +106,14 @@ variable "docker_image" {
 		err = os.WriteFile(variablesFile, []byte(variablesTF), 0644)
 		require.NoError(t, err, "Failed to write variables.tf")
 
-		// Base terraform options
+		// Base terraform options using environment-specific settings
+		sshPort, err := strconv.Atoi(env.ExternalPorts["ssh"])
+		require.NoError(t, err, "Failed to parse SSH port")
+
 		vars := map[string]interface{}{
 			"dokku_host":      "localhost",
-			"dokku_port":      3022,
-			"ssh_private_key": sshKeys.privateKeyPEM,
+			"dokku_port":      sshPort,
+			"ssh_private_key": env.SSHKeys.privateKeyPEM,
 			"docker_image":    "jmalloc/echo-server",
 		}
 
@@ -309,13 +145,13 @@ variable "docker_image" {
 		// Also, the proxy might be disabled due to complex configuration in the example
 
 		// First check if proxy is enabled for demo2
-		proxyCheckCmd := exec.Command("docker", "exec", containerName, "dokku", "proxy:report", "demo2")
+		proxyCheckCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "proxy:report", "demo2")
 		proxyOutput, err := proxyCheckCmd.CombinedOutput()
 		if err == nil {
 			t.Logf("Proxy status: %s", string(proxyOutput))
 			if strings.Contains(string(proxyOutput), "Proxy enabled:                 false") {
 				t.Logf("Proxy is disabled, enabling it...")
-				enableCmd := exec.Command("docker", "exec", containerName, "dokku", "proxy:enable", "demo2")
+				enableCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "proxy:enable", "demo2")
 				enableOutput, enableErr := enableCmd.CombinedOutput()
 				if enableErr != nil {
 					t.Logf("Enable proxy output: %s", string(enableOutput))
@@ -328,7 +164,7 @@ variable "docker_image" {
 		// No need to manually restart - that's the provider's job
 
 		// Manually reload nginx to ensure the proxy configuration is active
-		reloadCmd := exec.Command("docker", "exec", containerName, "nginx", "-s", "reload")
+		reloadCmd := exec.Command("docker", "exec", env.ContainerName, "nginx", "-s", "reload")
 		err = reloadCmd.Run()
 		if err != nil {
 			t.Logf("Nginx reload warning (expected in test environment): %v", err)
@@ -342,15 +178,19 @@ variable "docker_image" {
 		appName := "demo2" // Use demo2 as defined in the example
 
 		keyPair := &ssh.KeyPair{
-			PublicKey:  sshKeys.publicKeySSH,
-			PrivateKey: sshKeys.privateKeyPEM,
+			PublicKey:  env.SSHKeys.publicKeySSH,
+			PrivateKey: env.SSHKeys.privateKeyPEM,
 		}
+
+		// Convert external port string to int
+		customPort, err := strconv.Atoi(env.ExternalPorts["ssh"])
+		require.NoError(t, err, "Failed to parse SSH port")
 
 		host := ssh.Host{
 			Hostname:    "localhost",
 			SshKeyPair:  keyPair,
 			SshUserName: "dokku",
-			CustomPort:  3022,
+			CustomPort:  customPort,
 		}
 
 		// Test SSH connection first with a retry mechanism
@@ -418,9 +258,12 @@ variable "docker_image" {
 		var httpResponse string
 		var httpErr error
 
+		httpPort := env.ExternalPorts["http"]
+		httpURL := fmt.Sprintf("http://localhost:%s", httpPort)
+
 		for i := 0; i < maxRetries; i++ {
 			// Use curl to test HTTP connectivity since the app should be accessible via the exposed port
-			curlCmd := exec.Command("curl", "-s", "-f", "http://localhost:8080")
+			curlCmd := exec.Command("curl", "-s", "-f", "-H", "Host: example.com", httpURL)
 			output, err := curlCmd.Output()
 
 			if err == nil {
@@ -440,7 +283,7 @@ variable "docker_image" {
 
 		// Verify the response contains expected content from jmalloc/echo-server
 		assert.Contains(t, httpResponse, "Request served by", "HTTP response should contain 'Request served by' indicating the echo-server container is serving content")
-		assert.Contains(t, httpResponse, "Host: localhost:8080", "HTTP response should show the app received the request on port 8080")
+		assert.Contains(t, httpResponse, "Host: example.com", "HTTP response should show the app received the request on the correct port")
 
 		t.Logf("HTTP validation successful! Response preview: %.200s...", httpResponse)
 	})
@@ -450,7 +293,6 @@ variable "docker_image" {
 		terraform.Destroy(t, terraformOptions)
 	})
 
-	test_structure.RunTestStage(t, "cleanup_docker", func() {
-		cleanupDocker(t)
-	})
+	// Note: Final cleanup is handled by the defer statement at the beginning
+	// which calls cleanupTestEnvironment(t, env)
 }

--- a/test/examples_dokku_domain_test.go
+++ b/test/examples_dokku_domain_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/ssh"
@@ -13,21 +14,30 @@ import (
 )
 
 func TestExampleDokkuDomain(t *testing.T) {
+	t.Parallel()
+
 	// Copy the dokku_domain example directory first
 	testDir := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/resources/dokku_domain")
 
-	// Generate SSH keys first
-	var sshKeys *testSSHKeys
+	// Create isolated test environment
+	var env *testEnvironment
 	test_structure.RunTestStage(t, "generate_ssh_keys", func() {
-		sshKeys = generateSSHKeys(t, testDir)
+		env = createTestEnvironment(t, testDir)
 	})
 
+	// Ensure cleanup runs regardless of test outcome
+	defer func() {
+		if env != nil {
+			cleanupTestEnvironment(t, env)
+		}
+	}()
+
 	test_structure.RunTestStage(t, "setup_docker", func() {
-		setupDokkuContainer(t)
+		setupDokkuContainer(t, env)
 	})
 
 	test_structure.RunTestStage(t, "setup_ssh", func() {
-		setupSSH(t, sshKeys)
+		setupSSH(t, env)
 	})
 
 	test_structure.RunTestStage(t, "apply_terraform", func() {
@@ -63,11 +73,14 @@ variable "ssh_private_key" {
 		err := os.WriteFile(variablesFile, []byte(variablesTF), 0644)
 		require.NoError(t, err, "Failed to write variables.tf")
 
-		// Base terraform options
+		// Base terraform options using environment-specific settings
+		sshPort, err := strconv.Atoi(env.ExternalPorts["ssh"])
+		require.NoError(t, err, "Failed to parse SSH port")
+
 		vars := map[string]interface{}{
 			"dokku_host":      "localhost",
-			"dokku_port":      3022,
-			"ssh_private_key": sshKeys.privateKeyPEM,
+			"dokku_port":      sshPort,
+			"ssh_private_key": env.SSHKeys.privateKeyPEM,
 		}
 
 		terraformOptions := &terraform.Options{
@@ -98,15 +111,19 @@ variable "ssh_private_key" {
 		expectedDomain := "example.com" // As defined in the example
 
 		keyPair := &ssh.KeyPair{
-			PublicKey:  sshKeys.publicKeySSH,
-			PrivateKey: sshKeys.privateKeyPEM,
+			PublicKey:  env.SSHKeys.publicKeySSH,
+			PrivateKey: env.SSHKeys.privateKeyPEM,
 		}
+
+		// Convert external port string to int
+		customPort, err := strconv.Atoi(env.ExternalPorts["ssh"])
+		require.NoError(t, err, "Failed to parse SSH port")
 
 		host := ssh.Host{
 			Hostname:    "localhost",
 			SshKeyPair:  keyPair,
 			SshUserName: "dokku",
-			CustomPort:  3022,
+			CustomPort:  customPort,
 		}
 
 		// Verify the global domain exists
@@ -149,14 +166,14 @@ variable "ssh_private_key" {
 	})
 
 	test_structure.RunTestStage(t, "destroy_terraform", func() {
-		destroyTerraform(t, testDir)
+		terraformOptions := test_structure.LoadTerraformOptions(t, testDir)
+		// Use DestroyE since the apply might have failed and there might be nothing to destroy
+		_, destroyErr := terraform.DestroyE(t, terraformOptions)
+		if destroyErr != nil {
+			t.Logf("Destroy failed (expected if apply failed): %v", destroyErr)
+		}
 	})
 
-	test_structure.RunTestStage(t, "cleanup_test_files", func() {
-		cleanupTestFiles(t, testDir)
-	})
-
-	test_structure.RunTestStage(t, "cleanup_docker", func() {
-		cleanupDocker(t)
-	})
+	// Note: Final cleanup is handled by the defer statement at the beginning
+	// which calls cleanupTestEnvironment(t, env)
 }

--- a/test/examples_dokku_http_auth_test.go
+++ b/test/examples_dokku_http_auth_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -17,20 +18,29 @@ import (
 )
 
 func TestExampleDokkuHttpAuth(t *testing.T) {
+	t.Parallel()
+
 	// Copy the dokku_http_auth example directory first
 	testDir := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/resources/dokku_http_auth")
 
-	// Generate SSH keys first
-	var sshKeys *testSSHKeys
+	// Create isolated test environment
+	var env *testEnvironment
 	test_structure.RunTestStage(t, "generate_ssh_keys", func() {
-		sshKeys = generateSSHKeys(t, testDir)
+		env = createTestEnvironment(t, testDir)
 	})
 
+	// Ensure cleanup runs regardless of test outcome
+	defer func() {
+		if env != nil {
+			cleanupTestEnvironment(t, env)
+		}
+	}()
+
 	test_structure.RunTestStage(t, "setup_docker", func() {
-		setupDokkuContainer(t)
+		setupDokkuContainer(t, env)
 
 		// Install the http-auth plugin - ignore package update failures as they don't affect the plugin functionality
-		pluginInstallCmd := exec.Command("docker", "exec", containerName, "dokku", "plugin:install", "https://github.com/dokku/dokku-http-auth.git")
+		pluginInstallCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "plugin:install", "https://github.com/dokku/dokku-http-auth.git")
 		pluginInstallOutput, err := pluginInstallCmd.CombinedOutput()
 		pluginOutputStr := string(pluginInstallOutput)
 
@@ -44,7 +54,7 @@ func TestExampleDokkuHttpAuth(t *testing.T) {
 		}
 
 		// Verify plugin is available
-		pluginListCmd := exec.Command("docker", "exec", containerName, "dokku", "plugin:list")
+		pluginListCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "plugin:list")
 		listOutput, listErr := pluginListCmd.CombinedOutput()
 		if listErr == nil && strings.Contains(string(listOutput), "http-auth") {
 			t.Logf("✓ HTTP auth plugin is available and enabled")
@@ -57,7 +67,7 @@ func TestExampleDokkuHttpAuth(t *testing.T) {
 	})
 
 	test_structure.RunTestStage(t, "setup_ssh", func() {
-		setupSSH(t, sshKeys)
+		setupSSH(t, env)
 	})
 
 	test_structure.RunTestStage(t, "apply_terraform", func() {
@@ -93,11 +103,14 @@ variable "ssh_private_key" {
 		err := os.WriteFile(variablesFile, []byte(variablesTF), 0644)
 		require.NoError(t, err, "Failed to write variables.tf")
 
-		// Base terraform options
+		// Base terraform options using environment-specific settings
+		sshPort, err := strconv.Atoi(env.ExternalPorts["ssh"])
+		require.NoError(t, err, "Failed to parse SSH port")
+
 		vars := map[string]interface{}{
 			"dokku_host":      "localhost",
-			"dokku_port":      3022,
-			"ssh_private_key": sshKeys.privateKeyPEM,
+			"dokku_port":      sshPort,
+			"ssh_private_key": env.SSHKeys.privateKeyPEM,
 			"docker_image":    "jmalloc/echo-server",
 		}
 
@@ -121,7 +134,7 @@ variable "ssh_private_key" {
 		}
 
 		// Rebuild the app to ensure the http-auth settings are applied
-		rebuildCmd := exec.Command("docker", "exec", containerName, "dokku", "ps:rebuild", "demo")
+		rebuildCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "ps:rebuild", "demo")
 		rebuildOutput, err := rebuildCmd.CombinedOutput()
 		require.NoError(t, err, "Failed to rebuild app: %s", string(rebuildOutput))
 
@@ -134,13 +147,13 @@ variable "ssh_private_key" {
 		// Also, the proxy might be disabled due to complex configuration in the example
 
 		// First check if proxy is enabled for demo
-		proxyCheckCmd := exec.Command("docker", "exec", containerName, "dokku", "proxy:report", "demo")
+		proxyCheckCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "proxy:report", "demo")
 		proxyOutput, err := proxyCheckCmd.CombinedOutput()
 		if err == nil {
 			t.Logf("Proxy status: %s", string(proxyOutput))
 			if strings.Contains(string(proxyOutput), "Proxy enabled:                 false") {
 				t.Logf("Proxy is disabled, enabling it...")
-				enableCmd := exec.Command("docker", "exec", containerName, "dokku", "proxy:enable", "demo")
+				enableCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "proxy:enable", "demo")
 				enableOutput, enableErr := enableCmd.CombinedOutput()
 				if enableErr != nil {
 					t.Logf("Enable proxy output: %s", string(enableOutput))
@@ -150,11 +163,11 @@ variable "ssh_private_key" {
 		}
 
 		// Check and fix NO_VHOST issue - the app might have NO_VHOST=1 which prevents HTTP access
-		vhostCheckCmd := exec.Command("docker", "exec", containerName, "dokku", "config:get", "demo", "NO_VHOST")
+		vhostCheckCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "config:get", "demo", "NO_VHOST")
 		vhostOutput, err := vhostCheckCmd.CombinedOutput()
 		if err == nil && strings.TrimSpace(string(vhostOutput)) == "1" {
 			t.Logf("NO_VHOST is set to 1, unsetting it to enable HTTP access")
-			unsetVhostCmd := exec.Command("docker", "exec", containerName, "dokku", "config:unset", "demo", "NO_VHOST")
+			unsetVhostCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "config:unset", "demo", "NO_VHOST")
 			unsetOutput, unsetErr := unsetVhostCmd.CombinedOutput()
 			if unsetErr != nil {
 				t.Logf("Failed to unset NO_VHOST: %v, output: %s", unsetErr, string(unsetOutput))
@@ -163,7 +176,7 @@ variable "ssh_private_key" {
 
 				// Add a domain to enable proper HTTP routing
 				t.Logf("Adding domain to enable HTTP routing")
-				domainCmd := exec.Command("docker", "exec", containerName, "dokku", "domains:add", "demo", "demo.dokku.test")
+				domainCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "domains:add", "demo", "demo.dokku.test")
 				domainOutput, domainErr := domainCmd.CombinedOutput()
 				if domainErr != nil {
 					t.Logf("Domain add warning: %v, output: %s", domainErr, string(domainOutput))
@@ -173,7 +186,7 @@ variable "ssh_private_key" {
 
 				// Restart the app to apply the configuration change
 				t.Logf("Restarting app to apply NO_VHOST configuration change")
-				restartCmd := exec.Command("docker", "exec", containerName, "dokku", "ps:restart", "demo")
+				restartCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "ps:restart", "demo")
 				restartOutput, restartErr := restartCmd.CombinedOutput()
 				if restartErr != nil {
 					t.Logf("App restart warning: %v, output: %s", restartErr, string(restartOutput))
@@ -187,7 +200,7 @@ variable "ssh_private_key" {
 		}
 
 		// Manually reload nginx to ensure the proxy configuration is active
-		reloadCmd := exec.Command("docker", "exec", containerName, "nginx", "-s", "reload")
+		reloadCmd := exec.Command("docker", "exec", env.ContainerName, "nginx", "-s", "reload")
 		err = reloadCmd.Run()
 		if err != nil {
 			t.Logf("Nginx reload warning (expected in test environment): %v", err)
@@ -201,15 +214,19 @@ variable "ssh_private_key" {
 		appName := "demo"
 
 		keyPair := &ssh.KeyPair{
-			PublicKey:  sshKeys.publicKeySSH,
-			PrivateKey: sshKeys.privateKeyPEM,
+			PublicKey:  env.SSHKeys.publicKeySSH,
+			PrivateKey: env.SSHKeys.privateKeyPEM,
 		}
+
+		// Convert external port string to int
+		customPort, err := strconv.Atoi(env.ExternalPorts["ssh"])
+		require.NoError(t, err, "Failed to parse SSH port")
 
 		host := ssh.Host{
 			Hostname:    "localhost",
 			SshKeyPair:  keyPair,
 			SshUserName: "dokku",
-			CustomPort:  3022,
+			CustomPort:  customPort,
 		}
 
 		t.Logf("Validating dokku_http_auth example: %s", appName)
@@ -271,7 +288,7 @@ variable "ssh_private_key" {
 		t.Logf("=== Manual Plugin Verification ===")
 
 		// Check if plugin is installed and available
-		pluginListCmd := exec.Command("docker", "exec", containerName, "dokku", "plugin:list")
+		pluginListCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "plugin:list")
 		listOutput, listErr := pluginListCmd.CombinedOutput()
 		t.Logf("Plugin list: %s", string(listOutput))
 		if listErr != nil {
@@ -279,23 +296,26 @@ variable "ssh_private_key" {
 		}
 
 		// Check HTTP auth status for the app
-		authReportCmd := exec.Command("docker", "exec", containerName, "dokku", "http-auth:report", "demo")
+		authReportCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "http-auth:report", "demo")
 		authOutput, authErr := authReportCmd.CombinedOutput()
 		t.Logf("HTTP auth report: %s", string(authOutput))
 		if authErr != nil {
 			t.Logf("HTTP auth report error: %v", authErr)
 		}
 
-		// Check if users are configured
-		userListCmd := exec.Command("docker", "exec", containerName, "dokku", "http-auth:list", "demo")
-		userOutput, userErr := userListCmd.CombinedOutput()
-		t.Logf("HTTP auth users: %s", string(userOutput))
-		if userErr != nil {
-			t.Logf("HTTP auth user list error: %v", userErr)
+		// Validate HTTP auth configuration from the report output
+		if strings.Contains(string(authOutput), "Http auth enabled:             true") {
+			t.Logf("✓ HTTP auth is properly enabled")
+		} else {
+			t.Logf("⚠ HTTP auth may not be enabled")
+		}
+
+		if strings.Contains(string(authOutput), "Http auth users:") {
+			t.Logf("✓ HTTP auth users are configured")
 		}
 
 		// Check app status
-		appStatusCmd := exec.Command("docker", "exec", containerName, "dokku", "ps:report", "demo")
+		appStatusCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "ps:report", "demo")
 		statusOutput, statusErr := appStatusCmd.CombinedOutput()
 		t.Logf("App status: %s", string(statusOutput))
 		if statusErr != nil {
@@ -303,7 +323,7 @@ variable "ssh_private_key" {
 		}
 
 		// Check nginx config
-		nginxCheckCmd := exec.Command("docker", "exec", containerName, "ls", "-la", "/home/dokku/demo/nginx.conf.d/")
+		nginxCheckCmd := exec.Command("docker", "exec", env.ContainerName, "ls", "-la", "/home/dokku/demo/nginx.conf.d/")
 		nginxOutput, nginxErr := nginxCheckCmd.CombinedOutput()
 		t.Logf("Nginx config directory: %s", string(nginxOutput))
 		if nginxErr != nil {
@@ -314,10 +334,10 @@ variable "ssh_private_key" {
 	})
 
 	test_structure.RunTestStage(t, "destroy_terraform", func() {
-		destroyTerraform(t, testDir)
+		terraformOptions := test_structure.LoadTerraformOptions(t, testDir)
+		terraform.Destroy(t, terraformOptions)
 	})
 
-	test_structure.RunTestStage(t, "cleanup_docker", func() {
-		cleanupDocker(t)
-	})
+	// Note: Final cleanup is handled by the defer statement at the beginning
+	// which calls cleanupTestEnvironment(t, env)
 }

--- a/test/examples_dokku_nats_test.go
+++ b/test/examples_dokku_nats_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -18,47 +19,43 @@ import (
 )
 
 func TestExampleDokkuNats(t *testing.T) {
+	t.Parallel()
+
 	// Copy the dokku_nats example directory first
 	testDir := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/resources/dokku_nats")
 
-	// Setup cleanup using defer to ensure it always runs
-	defer test_structure.RunTestStage(t, "cleanup_docker", func() {
-		cleanupDocker(t)
-	})
-
-	defer test_structure.RunTestStage(t, "cleanup_test_files", func() {
-		cleanupTestFiles(t, testDir)
-	})
-
-	defer test_structure.RunTestStage(t, "destroy_terraform", func() {
-		destroyTerraform(t, testDir)
-	})
-
-	// Generate SSH keys first
-	var sshKeys *testSSHKeys
+	// Create isolated test environment
+	var env *testEnvironment
 	test_structure.RunTestStage(t, "generate_ssh_keys", func() {
-		sshKeys = generateSSHKeys(t, testDir)
+		env = createTestEnvironment(t, testDir)
 	})
+
+	// Ensure cleanup runs regardless of test outcome
+	defer func() {
+		if env != nil {
+			cleanupTestEnvironment(t, env)
+		}
+	}()
 
 	test_structure.RunTestStage(t, "setup_docker", func() {
-		setupDokkuContainer(t)
+		setupDokkuContainer(t, env)
 	})
 
 	test_structure.RunTestStage(t, "setup_ssh", func() {
-		setupSSH(t, sshKeys)
+		setupSSH(t, env)
 	})
 
 	test_structure.RunTestStage(t, "install_plugins", func() {
 		// Install the NATS plugin
 		t.Logf("Installing NATS plugin...")
 
-		installCmd := exec.Command("docker", "exec", containerName, "dokku", "plugin:install", "https://github.com/dokku/dokku-nats.git", "nats")
+		installCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "plugin:install", "https://github.com/dokku/dokku-nats.git", "nats")
 		output, err := installCmd.CombinedOutput()
 		t.Logf("Plugin install output: %s", string(output))
 		require.NoError(t, err, "Failed to install NATS plugin")
 
 		// Verify plugin was installed
-		verifyCmd := exec.Command("docker", "exec", containerName, "dokku", "plugin:list")
+		verifyCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "plugin:list")
 		verifyOutput, err := verifyCmd.CombinedOutput()
 		t.Logf("Plugin list output: %s", string(verifyOutput))
 		require.NoError(t, err, "Failed to list plugins")
@@ -71,7 +68,7 @@ func TestExampleDokkuNats(t *testing.T) {
 		t.Logf("Cleaning up existing nats services...")
 
 		// Try to destroy existing service (ignore errors if it doesn't exist)
-		destroyCmd := exec.Command("docker", "exec", containerName, "dokku", "nats:destroy", serviceName, "--force")
+		destroyCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "nats:destroy", serviceName, "--force")
 		destroyOutput, err := destroyCmd.CombinedOutput()
 		if err != nil {
 			t.Logf("Service cleanup (expected if service doesn't exist): %v, output: %s", err, string(destroyOutput))
@@ -80,7 +77,7 @@ func TestExampleDokkuNats(t *testing.T) {
 		}
 
 		// Also clean up any leftover containers using Docker command within the dokku container
-		containerCleanupCmd := exec.Command("docker", "exec", containerName, "docker", "container", "rm", "-f", "dokku.nats.demo")
+		containerCleanupCmd := exec.Command("docker", "exec", env.ContainerName, "docker", "container", "rm", "-f", "dokku.nats.demo")
 		containerCleanupOutput, containerErr := containerCleanupCmd.CombinedOutput()
 		if containerErr != nil {
 			t.Logf("Container cleanup (expected if container doesn't exist): %v, output: %s", containerErr, string(containerCleanupOutput))
@@ -89,7 +86,7 @@ func TestExampleDokkuNats(t *testing.T) {
 		}
 
 		// Clean up any nats volumes that might conflict
-		volumeCleanupCmd := exec.Command("docker", "exec", containerName, "docker", "volume", "rm", "-f", "dokku.nats.demo")
+		volumeCleanupCmd := exec.Command("docker", "exec", env.ContainerName, "docker", "volume", "rm", "-f", "dokku.nats.demo")
 		volumeCleanupOutput, volumeErr := volumeCleanupCmd.CombinedOutput()
 		if volumeErr != nil {
 			t.Logf("Volume cleanup (expected if volume doesn't exist): %v, output: %s", volumeErr, string(volumeCleanupOutput))
@@ -131,11 +128,14 @@ variable "ssh_private_key" {
 		err := os.WriteFile(variablesFile, []byte(variablesTF), 0644)
 		require.NoError(t, err, "Failed to write variables.tf")
 
-		// Base terraform options
+		// Base terraform options using environment-specific settings
+		sshPort, err := strconv.Atoi(env.ExternalPorts["ssh"])
+		require.NoError(t, err, "Failed to parse SSH port")
+
 		vars := map[string]interface{}{
 			"dokku_host":      "localhost",
-			"dokku_port":      3022,
-			"ssh_private_key": sshKeys.privateKeyPEM,
+			"dokku_port":      sshPort,
+			"ssh_private_key": env.SSHKeys.privateKeyPEM,
 		}
 
 		terraformOptions := &terraform.Options{
@@ -168,15 +168,19 @@ variable "ssh_private_key" {
 		serviceName := "demo" // Use service name as identifier
 
 		keyPair := &ssh.KeyPair{
-			PublicKey:  sshKeys.publicKeySSH,
-			PrivateKey: sshKeys.privateKeyPEM,
+			PublicKey:  env.SSHKeys.publicKeySSH,
+			PrivateKey: env.SSHKeys.privateKeyPEM,
 		}
+
+		// Convert external port string to int
+		customPort, err := strconv.Atoi(env.ExternalPorts["ssh"])
+		require.NoError(t, err, "Failed to parse SSH port")
 
 		host := ssh.Host{
 			Hostname:    "localhost",
 			SshKeyPair:  keyPair,
 			SshUserName: "dokku",
-			CustomPort:  3022,
+			CustomPort:  customPort,
 		}
 
 		t.Logf("Validating dokku_nats example: %s", serviceName)
@@ -208,7 +212,7 @@ variable "ssh_private_key" {
 		t.Logf("Testing NATS connection for service: %s", serviceName)
 
 		// Get service info to validate the service exists and is properly configured
-		infoCmd := exec.Command("docker", "exec", containerName, "dokku", "nats:info", serviceName)
+		infoCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "nats:info", serviceName)
 		infoOutput, infoErr := infoCmd.CombinedOutput()
 		require.NoError(t, infoErr, "Failed to get nats service info")
 
@@ -238,5 +242,6 @@ variable "ssh_private_key" {
 		}
 	})
 
-	// Note: Cleanup stages are now handled by defer statements at the top of the function
+	// Note: Final cleanup is handled by the defer statement at the beginning
+	// which calls cleanupTestEnvironment(t, env)
 }

--- a/test/examples_dokku_plugin_test.go
+++ b/test/examples_dokku_plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/ssh"
@@ -14,34 +15,43 @@ import (
 )
 
 func TestExampleDokkuPlugin(t *testing.T) {
+	t.Parallel()
+
 	// Copy the dokku_plugin example directory first
 	testDir := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/resources/dokku_plugin")
 
-	// Generate SSH keys first
-	var sshKeys *testSSHKeys
+	// Create isolated test environment
+	var env *testEnvironment
 	test_structure.RunTestStage(t, "generate_ssh_keys", func() {
-		sshKeys = generateSSHKeys(t, testDir)
+		env = createTestEnvironment(t, testDir)
 	})
 
+	// Ensure cleanup runs regardless of test outcome
+	defer func() {
+		if env != nil {
+			cleanupTestEnvironment(t, env)
+		}
+	}()
+
 	test_structure.RunTestStage(t, "setup_docker", func() {
-		setupDokkuContainer(t)
+		setupDokkuContainer(t, env)
 	})
 
 	test_structure.RunTestStage(t, "setup_ssh", func() {
-		setupSSH(t, sshKeys)
+		setupSSH(t, env)
 	})
 
 	test_structure.RunTestStage(t, "install_plugins", func() {
 		// Install the NATS plugin
 		t.Logf("Installing NATS plugin...")
 
-		installCmd := exec.Command("docker", "exec", containerName, "dokku", "plugin:install", "https://github.com/dokku/dokku-nats.git", "nats")
+		installCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "plugin:install", "https://github.com/dokku/dokku-nats.git", "nats")
 		output, err := installCmd.CombinedOutput()
 		t.Logf("Plugin install output: %s", string(output))
 		require.NoError(t, err, "Failed to install NATS plugin")
 
 		// Verify plugin was installed
-		verifyCmd := exec.Command("docker", "exec", containerName, "dokku", "plugin:list")
+		verifyCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "plugin:list")
 		verifyOutput, err := verifyCmd.CombinedOutput()
 		t.Logf("Plugin list output: %s", string(verifyOutput))
 		require.NoError(t, err, "Failed to list plugins")
@@ -81,11 +91,14 @@ variable "ssh_private_key" {
 		err := os.WriteFile(variablesFile, []byte(variablesTF), 0644)
 		require.NoError(t, err, "Failed to write variables.tf")
 
-		// Base terraform options
+		// Base terraform options using environment-specific settings
+		sshPort, err := strconv.Atoi(env.ExternalPorts["ssh"])
+		require.NoError(t, err, "Failed to parse SSH port")
+
 		vars := map[string]interface{}{
 			"dokku_host":      "localhost",
-			"dokku_port":      3022,
-			"ssh_private_key": sshKeys.privateKeyPEM,
+			"dokku_port":      sshPort,
+			"ssh_private_key": env.SSHKeys.privateKeyPEM,
 		}
 
 		terraformOptions := &terraform.Options{
@@ -116,15 +129,19 @@ variable "ssh_private_key" {
 		pluginName := "nats" // Use plugin name as identifier
 
 		keyPair := &ssh.KeyPair{
-			PublicKey:  sshKeys.publicKeySSH,
-			PrivateKey: sshKeys.privateKeyPEM,
+			PublicKey:  env.SSHKeys.publicKeySSH,
+			PrivateKey: env.SSHKeys.privateKeyPEM,
 		}
+
+		// Convert external port string to int
+		customPort, err := strconv.Atoi(env.ExternalPorts["ssh"])
+		require.NoError(t, err, "Failed to parse SSH port")
 
 		host := ssh.Host{
 			Hostname:    "localhost",
 			SshKeyPair:  keyPair,
 			SshUserName: "dokku",
-			CustomPort:  3022,
+			CustomPort:  customPort,
 		}
 
 		t.Logf("Validating dokku_plugin example: %s", pluginName)
@@ -140,14 +157,10 @@ variable "ssh_private_key" {
 	})
 
 	test_structure.RunTestStage(t, "destroy_terraform", func() {
-		destroyTerraform(t, testDir)
+		terraformOptions := test_structure.LoadTerraformOptions(t, testDir)
+		terraform.Destroy(t, terraformOptions)
 	})
 
-	test_structure.RunTestStage(t, "cleanup_test_files", func() {
-		cleanupTestFiles(t, testDir)
-	})
-
-	test_structure.RunTestStage(t, "cleanup_docker", func() {
-		cleanupDocker(t)
-	})
+	// Note: Final cleanup is handled by the defer statement at the beginning
+	// which calls cleanupTestEnvironment(t, env)
 }

--- a/test/examples_dokku_postgres_test.go
+++ b/test/examples_dokku_postgres_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -16,47 +17,43 @@ import (
 )
 
 func TestExampleDokkuPostgres(t *testing.T) {
+	t.Parallel()
+
 	// Copy the dokku_postgres example directory first
 	testDir := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/resources/dokku_postgres")
 
-	// Setup cleanup using defer to ensure it always runs
-	defer test_structure.RunTestStage(t, "cleanup_docker", func() {
-		cleanupDocker(t)
-	})
-
-	defer test_structure.RunTestStage(t, "cleanup_test_files", func() {
-		cleanupTestFiles(t, testDir)
-	})
-
-	defer test_structure.RunTestStage(t, "destroy_terraform", func() {
-		destroyTerraform(t, testDir)
-	})
-
-	// Generate SSH keys first
-	var sshKeys *testSSHKeys
+	// Create isolated test environment
+	var env *testEnvironment
 	test_structure.RunTestStage(t, "generate_ssh_keys", func() {
-		sshKeys = generateSSHKeys(t, testDir)
+		env = createTestEnvironment(t, testDir)
 	})
+
+	// Ensure cleanup runs regardless of test outcome
+	defer func() {
+		if env != nil {
+			cleanupTestEnvironment(t, env)
+		}
+	}()
 
 	test_structure.RunTestStage(t, "setup_docker", func() {
-		setupDokkuContainer(t)
+		setupDokkuContainer(t, env)
 	})
 
 	test_structure.RunTestStage(t, "setup_ssh", func() {
-		setupSSH(t, sshKeys)
+		setupSSH(t, env)
 	})
 
 	test_structure.RunTestStage(t, "install_plugins", func() {
 		// Install the PostgreSQL plugin
 		t.Logf("Installing PostgreSQL plugin...")
 
-		installCmd := exec.Command("docker", "exec", containerName, "dokku", "plugin:install", "https://github.com/dokku/dokku-postgres.git")
+		installCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "plugin:install", "https://github.com/dokku/dokku-postgres.git")
 		output, err := installCmd.CombinedOutput()
 		t.Logf("Plugin install output: %s", string(output))
 		require.NoError(t, err, "Failed to install PostgreSQL plugin")
 
 		// Verify plugin was installed
-		verifyCmd := exec.Command("docker", "exec", containerName, "dokku", "plugin:list")
+		verifyCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "plugin:list")
 		verifyOutput, err := verifyCmd.CombinedOutput()
 		t.Logf("Plugin list output: %s", string(verifyOutput))
 		require.NoError(t, err, "Failed to list plugins")
@@ -69,7 +66,7 @@ func TestExampleDokkuPostgres(t *testing.T) {
 		t.Logf("Cleaning up existing postgres services...")
 
 		// Try to destroy existing service (ignore errors if it doesn't exist)
-		destroyCmd := exec.Command("docker", "exec", containerName, "dokku", "postgres:destroy", serviceName, "--force")
+		destroyCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "postgres:destroy", serviceName, "--force")
 		destroyOutput, err := destroyCmd.CombinedOutput()
 		if err != nil {
 			t.Logf("Service cleanup (expected if service doesn't exist): %v, output: %s", err, string(destroyOutput))
@@ -78,7 +75,7 @@ func TestExampleDokkuPostgres(t *testing.T) {
 		}
 
 		// Also clean up any leftover containers using Docker command within the dokku container
-		containerCleanupCmd := exec.Command("docker", "exec", containerName, "docker", "container", "rm", "-f", "dokku.postgres.demo")
+		containerCleanupCmd := exec.Command("docker", "exec", env.ContainerName, "docker", "container", "rm", "-f", "dokku.postgres.demo")
 		containerCleanupOutput, containerErr := containerCleanupCmd.CombinedOutput()
 		if containerErr != nil {
 			t.Logf("Container cleanup (expected if container doesn't exist): %v, output: %s", containerErr, string(containerCleanupOutput))
@@ -87,7 +84,7 @@ func TestExampleDokkuPostgres(t *testing.T) {
 		}
 
 		// Clean up any postgres volumes that might conflict
-		volumeCleanupCmd := exec.Command("docker", "exec", containerName, "docker", "volume", "rm", "-f", "dokku.postgres.demo")
+		volumeCleanupCmd := exec.Command("docker", "exec", env.ContainerName, "docker", "volume", "rm", "-f", "dokku.postgres.demo")
 		volumeCleanupOutput, volumeErr := volumeCleanupCmd.CombinedOutput()
 		if volumeErr != nil {
 			t.Logf("Volume cleanup (expected if volume doesn't exist): %v, output: %s", volumeErr, string(volumeCleanupOutput))
@@ -129,11 +126,14 @@ variable "ssh_private_key" {
 		err := os.WriteFile(variablesFile, []byte(variablesTF), 0644)
 		require.NoError(t, err, "Failed to write variables.tf")
 
-		// Base terraform options
+		// Base terraform options using environment-specific settings
+		sshPort, err := strconv.Atoi(env.ExternalPorts["ssh"])
+		require.NoError(t, err, "Failed to parse SSH port")
+
 		vars := map[string]interface{}{
 			"dokku_host":      "localhost",
-			"dokku_port":      3022,
-			"ssh_private_key": sshKeys.privateKeyPEM,
+			"dokku_port":      sshPort,
+			"ssh_private_key": env.SSHKeys.privateKeyPEM,
 		}
 
 		terraformOptions := &terraform.Options{
@@ -166,15 +166,19 @@ variable "ssh_private_key" {
 		serviceName := "demo" // Use service name as identifier
 
 		keyPair := &ssh.KeyPair{
-			PublicKey:  sshKeys.publicKeySSH,
-			PrivateKey: sshKeys.privateKeyPEM,
+			PublicKey:  env.SSHKeys.publicKeySSH,
+			PrivateKey: env.SSHKeys.privateKeyPEM,
 		}
+
+		// Convert external port string to int
+		customPort, err := strconv.Atoi(env.ExternalPorts["ssh"])
+		require.NoError(t, err, "Failed to parse SSH port")
 
 		host := ssh.Host{
 			Hostname:    "localhost",
 			SshKeyPair:  keyPair,
 			SshUserName: "dokku",
-			CustomPort:  3022,
+			CustomPort:  customPort,
 		}
 
 		t.Logf("Validating dokku_postgres example: %s", serviceName)
@@ -206,7 +210,7 @@ variable "ssh_private_key" {
 		t.Logf("Testing PostgreSQL connection for service: %s", serviceName)
 
 		// Get service info to validate the service exists and is properly configured
-		infoCmd := exec.Command("docker", "exec", containerName, "dokku", "postgres:info", serviceName)
+		infoCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "postgres:info", serviceName)
 		infoOutput, infoErr := infoCmd.CombinedOutput()
 		require.NoError(t, infoErr, "Failed to get postgres service info")
 
@@ -224,7 +228,7 @@ variable "ssh_private_key" {
 			t.Logf("Service appears to be running")
 
 			// Only attempt connection tests if the service is not in exited state
-			connectionTestCmd := exec.Command("docker", "exec", containerName, "dokku", "postgres:connect", serviceName, "--", "psql", "-c", "SELECT version();")
+			connectionTestCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "postgres:connect", serviceName, "--", "psql", "-c", "SELECT version();")
 			connectionOutput, err := connectionTestCmd.CombinedOutput()
 
 			if err == nil {
@@ -236,5 +240,6 @@ variable "ssh_private_key" {
 		}
 	})
 
-	// Note: Cleanup stages are now handled by defer statements at the top of the function
+	// Note: Final cleanup is handled by the defer statement at the beginning
+	// which calls cleanupTestEnvironment(t, env)
 }

--- a/test/simple_test.go
+++ b/test/simple_test.go
@@ -1,8 +1,11 @@
 package test
 
 import (
+	"fmt"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,35 +17,47 @@ import (
 )
 
 func TestSimple(t *testing.T) {
-	// Removed t.Parallel() due to Docker container name conflicts
+	t.Parallel()
 
 	// Copy the specific test subdirectory
 	sourceDir := filepath.Join("test", "simple")
 	testDir := test_structure.CopyTerraformFolderToTemp(t, "../", sourceDir)
 
-	// Generate SSH keys first
-	var sshKeys *testSSHKeys
+	// Create isolated test environment
+	var env *testEnvironment
 	test_structure.RunTestStage(t, "generate_ssh_keys", func() {
-		sshKeys = generateSSHKeys(t, testDir)
+		env = createTestEnvironment(t, testDir)
 	})
 
+	// Ensure cleanup runs regardless of test outcome
+	defer func() {
+		if env != nil {
+			cleanupTestEnvironment(t, env)
+		}
+	}()
+
 	test_structure.RunTestStage(t, "setup_docker", func() {
-		setupDokkuContainer(t)
+		setupDokkuContainer(t, env)
 	})
 
 	test_structure.RunTestStage(t, "setup_ssh", func() {
-		setupSSH(t, sshKeys)
+		setupSSH(t, env)
 	})
 
 	test_structure.RunTestStage(t, "apply_terraform", func() {
 		// Define test-specific configuration inline
-		appName := "simple-test-app"
+		// Convert to lowercase and clean up the name for Dokku compatibility
+		testName := strings.ToLower(strings.ReplaceAll(t.Name(), "/", "-"))
+		appName := fmt.Sprintf("simple-test-%s", testName)
 
-		// Base terraform options
+		// Base terraform options using environment-specific settings
+		sshPort, err := strconv.Atoi(env.ExternalPorts["ssh"])
+		require.NoError(t, err, "Failed to parse SSH port")
+
 		vars := map[string]interface{}{
 			"dokku_host":      "localhost",
-			"dokku_port":      3022,
-			"ssh_private_key": sshKeys.privateKeyPEM,
+			"dokku_port":      sshPort,
+			"ssh_private_key": env.SSHKeys.privateKeyPEM,
 			"app_name":        appName,
 		}
 
@@ -66,34 +81,43 @@ func TestSimple(t *testing.T) {
 	})
 
 	test_structure.RunTestStage(t, "validate_dokku", func() {
-		appName := "simple-test-app"
+		// Convert to lowercase and clean up the name for Dokku compatibility
+		testName := strings.ToLower(strings.ReplaceAll(t.Name(), "/", "-"))
+		appName := fmt.Sprintf("simple-test-%s", testName)
 
 		keyPair := &ssh.KeyPair{
-			PublicKey:  sshKeys.publicKeySSH,
-			PrivateKey: sshKeys.privateKeyPEM,
+			PublicKey:  env.SSHKeys.publicKeySSH,
+			PrivateKey: env.SSHKeys.privateKeyPEM,
 		}
+
+		// Convert external port string to int
+		customPort, err := strconv.Atoi(env.ExternalPorts["ssh"])
+		require.NoError(t, err, "Failed to parse SSH port")
 
 		host := ssh.Host{
 			Hostname:    "localhost",
 			SshKeyPair:  keyPair,
 			SshUserName: "dokku",
-			CustomPort:  3022,
+			CustomPort:  customPort,
 		}
 
 		validateSimpleApp(t, host, appName)
 	})
 
 	test_structure.RunTestStage(t, "validate_http", func() {
-		// Test HTTP accessibility
+		// Test HTTP accessibility using the environment's external HTTP port
 		maxRetries := 10
 		retryInterval := 3 * time.Second
 
 		var httpResponse string
 		var httpErr error
 
+		httpPort := env.ExternalPorts["http"]
+		httpURL := fmt.Sprintf("http://localhost:%s", httpPort)
+
 		for i := 0; i < maxRetries; i++ {
 			// Use curl to test HTTP connectivity since the app should be accessible via the exposed port
-			curlCmd := exec.Command("curl", "-s", "-f", "http://localhost:8080")
+			curlCmd := exec.Command("curl", "-s", "-f", httpURL)
 			output, err := curlCmd.Output()
 
 			if err == nil {
@@ -113,7 +137,7 @@ func TestSimple(t *testing.T) {
 
 		// Verify the response contains expected content from jmalloc/echo-server
 		assert.Contains(t, httpResponse, "Request served by", "HTTP response should contain 'Request served by' indicating the echo-server container is serving content")
-		assert.Contains(t, httpResponse, "Host: localhost:8080", "HTTP response should show the app received the request on port 8080")
+		assert.Contains(t, httpResponse, fmt.Sprintf("Host: localhost:%s", httpPort), "HTTP response should show the app received the request on the correct port")
 
 		t.Logf("HTTP validation successful! Response preview: %.200s...", httpResponse)
 	})
@@ -123,7 +147,6 @@ func TestSimple(t *testing.T) {
 		terraform.Destroy(t, terraformOptions)
 	})
 
-	test_structure.RunTestStage(t, "cleanup_docker", func() {
-		cleanupDocker(t)
-	})
+	// Note: Final cleanup is handled by the defer statement at the beginning
+	// which calls cleanupTestEnvironment(t, env)
 }

--- a/test/test_helpers.go
+++ b/test/test_helpers.go
@@ -6,9 +6,11 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -33,17 +35,109 @@ func getDokkuVersion() string {
 	return version
 }
 
-const (
-	containerName = "dokku-test-container"
-	sshPort       = "3022"
-	httpPort      = "8080"
-)
+// testEnvironment holds all resources for a single test
+type testEnvironment struct {
+	ContainerName string
+	NetworkName   string
+	SSHKeys       *testSSHKeys
+	InternalPorts map[string]string
+	ExternalPorts map[string]string
+	TestDir       string
+}
 
 type testSSHKeys struct {
 	privateKeyPEM  string
 	publicKeySSH   string
 	privateKeyPath string
 	publicKeyPath  string
+}
+
+// createTestEnvironment sets up an isolated test environment for parallel execution
+func createTestEnvironment(t *testing.T, testDir string) *testEnvironment {
+	// Generate unique names for resources using test name and timestamp to avoid conflicts
+	timestamp := time.Now().UnixNano()
+	testName := strings.ReplaceAll(t.Name(), "/", "-")
+
+	containerName := fmt.Sprintf("dokku-test-%s-%d", testName, timestamp)
+	networkName := fmt.Sprintf("network-%s-%d", testName, timestamp)
+
+	// Create Docker network for test isolation
+	createNetworkCmd := exec.Command("docker", "network", "create", networkName)
+	if err := createNetworkCmd.Run(); err != nil {
+		t.Logf("Warning: Failed to create network %s: %v", networkName, err)
+		// Continue without custom network - tests will use default bridge
+		networkName = ""
+	} else {
+		t.Logf("Created Docker network: %s", networkName)
+	}
+
+	// Generate dynamic external ports to avoid conflicts
+	sshPort := findAvailablePort(t)
+	httpPort := findAvailablePort(t)
+
+	// Generate SSH keys for this test environment
+	sshKeys := generateSSHKeys(t, testDir)
+
+	return &testEnvironment{
+		ContainerName: containerName,
+		NetworkName:   networkName,
+		SSHKeys:       sshKeys,
+		InternalPorts: map[string]string{
+			"ssh":  "22",
+			"http": "80",
+		},
+		ExternalPorts: map[string]string{
+			"ssh":  strconv.Itoa(sshPort),
+			"http": strconv.Itoa(httpPort),
+		},
+		TestDir: testDir,
+	}
+}
+
+// findAvailablePort finds and returns an available ephemeral TCP port.
+func findAvailablePort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Failed to find an available port: %v", err)
+	}
+	defer listener.Close()
+
+	addr := listener.Addr().(*net.TCPAddr)
+	port := addr.Port
+	t.Logf("Found available port: %d", port)
+	return port
+}
+
+// cleanupTestEnvironment cleans up all resources for a test environment
+func cleanupTestEnvironment(t *testing.T, env *testEnvironment) {
+	if env == nil {
+		return
+	}
+
+	// Stop and remove container
+	if env.ContainerName != "" {
+		stopCmd := exec.Command("docker", "stop", env.ContainerName)
+		stopCmd.Run() // Ignore errors - container might already be stopped
+
+		removeCmd := exec.Command("docker", "rm", "-f", env.ContainerName)
+		removeCmd.Run() // Ignore errors - container might not exist
+
+		t.Logf("Cleaned up container: %s", env.ContainerName)
+	}
+
+	// Remove network if we created one
+	if env.NetworkName != "" {
+		removeNetworkCmd := exec.Command("docker", "network", "rm", env.NetworkName)
+		if err := removeNetworkCmd.Run(); err != nil {
+			t.Logf("Warning: Failed to remove network %s: %v", env.NetworkName, err)
+		} else {
+			t.Logf("Cleaned up network: %s", env.NetworkName)
+		}
+	}
+
+	// Clean up test files
+	cleanupTestFiles(t, env.TestDir)
 }
 
 func generateSSHKeys(t *testing.T, testDir string) *testSSHKeys {
@@ -62,6 +156,10 @@ func generateSSHKeys(t *testing.T, testDir string) *testSSHKeys {
 	publicKey, err := cryptossh.NewPublicKey(&privateKey.PublicKey)
 	require.NoError(t, err, "Failed to generate public key")
 	publicKeySSH := string(cryptossh.MarshalAuthorizedKey(publicKey))
+
+	// Ensure the directory exists
+	err = os.MkdirAll(testDir, 0755)
+	require.NoError(t, err, "Failed to create test directory")
 
 	// Write keys to files
 	privateKeyPath := filepath.Join(testDir, "ssh_key")
@@ -83,28 +181,40 @@ func generateSSHKeys(t *testing.T, testDir string) *testSSHKeys {
 	}
 }
 
-func setupDokkuContainer(t *testing.T) {
+func setupDokkuContainer(t *testing.T, env *testEnvironment) {
 	// Try to remove any existing container with the same name
-	cleanupCmd := exec.Command("docker", "rm", "-f", containerName)
+	cleanupCmd := exec.Command("docker", "rm", "-f", env.ContainerName)
 	cleanupCmd.Run()
 
 	// Get the Dokku version to use
 	dokkuVersion := getDokkuVersion()
 	dokkuImageName := fmt.Sprintf("dokku/dokku:%s", dokkuVersion)
 
+	// Prepare run options with dynamic naming and networking
+	otherOptions := []string{
+		"-e", "DOKKU_HOSTNAME=dokku.test",
+		"-e", "DOKKU_HOST_ROOT=/home/dokku/dokku",
+		"-v", "/var/run/docker.sock:/var/run/docker.sock",
+		"--add-host", "host.docker.internal:host-gateway",
+	}
+
+	// Always use port mapping for external access, regardless of network
+	otherOptions = append(otherOptions,
+		"-p", fmt.Sprintf("%s:%s", env.ExternalPorts["ssh"], env.InternalPorts["ssh"]),
+		"-p", fmt.Sprintf("%s:%s", env.ExternalPorts["http"], env.InternalPorts["http"]),
+	)
+
+	// Add network configuration if we have a custom network (for container-to-container communication)
+	if env.NetworkName != "" {
+		otherOptions = append(otherOptions, "--network", env.NetworkName)
+	}
+
 	// Run the Dokku container
 	runOptions := &docker.RunOptions{
-		Name:       containerName,
-		Detach:     true,
-		Privileged: true,
-		OtherOptions: []string{
-			"-p", fmt.Sprintf("%s:22", sshPort),
-			"-p", fmt.Sprintf("%s:80", httpPort),
-			"-e", "DOKKU_HOSTNAME=dokku.test",
-			"-e", "DOKKU_HOST_ROOT=/home/dokku/dokku",
-			"-v", "/var/run/docker.sock:/var/run/docker.sock",
-			"--add-host", "host.docker.internal:host-gateway",
-		},
+		Name:         env.ContainerName,
+		Detach:       true,
+		Privileged:   true,
+		OtherOptions: otherOptions,
 	}
 
 	docker.Run(t, dokkuImageName, runOptions)
@@ -115,14 +225,13 @@ func setupDokkuContainer(t *testing.T) {
 	sshServiceRunning := false
 
 	for i := 0; i < retries; i++ {
-		// Check if SSH is running inside the container
-		sshCheckCmd := exec.Command("docker", "exec", containerName, "service", "ssh", "status")
+		sshCheckCmd := exec.Command("docker", "exec", env.ContainerName, "service", "ssh", "status")
 		err := sshCheckCmd.Run()
 		if err == nil {
 			sshServiceRunning = true
 			break
 		}
-		require.Error(t, err, "SSH service check failed")
+		t.Logf("SSH service check attempt %d failed: %v", i+1, err)
 		time.Sleep(retryInterval)
 	}
 
@@ -130,7 +239,7 @@ func setupDokkuContainer(t *testing.T) {
 	dokkuInstalled := false
 	if sshServiceRunning {
 		// Check if dokku command works
-		dokkuCheckCmd := exec.Command("docker", "exec", containerName, "dokku", "--version")
+		dokkuCheckCmd := exec.Command("docker", "exec", env.ContainerName, "dokku", "--version")
 		err := dokkuCheckCmd.Run()
 		if err == nil {
 			dokkuInstalled = true
@@ -140,15 +249,24 @@ func setupDokkuContainer(t *testing.T) {
 	// Only proceed if both SSH and Dokku are working
 	require.True(t, sshServiceRunning && dokkuInstalled, "Container basic checks passed")
 
+	// Verify container is actually running and ports are mapped
+	inspectCmd := exec.Command("docker", "inspect", env.ContainerName, "--format", "{{.State.Running}} {{.NetworkSettings.Ports}}")
+	inspectOutput, err := inspectCmd.CombinedOutput()
+	if err != nil {
+		t.Logf("Container inspection failed: %v", err)
+	} else {
+		t.Logf("Container status and ports: %s", string(inspectOutput))
+	}
+
 	// Wait additional time to ensure services are fully stabilized
 	t.Logf("Container ready, waiting additional 15 seconds for services to fully stabilize...")
 	time.Sleep(15 * time.Second)
 }
 
-func setupSSH(t *testing.T, keys *testSSHKeys) {
+func setupSSH(t *testing.T, env *testEnvironment) {
 	// Use the generated SSH keys
-	pubKey := keys.publicKeySSH
-	privateKeyPath := keys.privateKeyPath
+	pubKey := env.SSHKeys.publicKeySSH
+	privateKeyPath := env.SSHKeys.privateKeyPath
 
 	// Fix permissions on private key first
 	exec.Command("chmod", "600", privateKeyPath).Run()
@@ -159,7 +277,7 @@ func setupSSH(t *testing.T, keys *testSSHKeys) {
 	// Multiple attempts to set up SSH properly
 	for attempt := 0; attempt < 3; attempt++ {
 		// Configure SSH key in the container with more thorough setup
-		setupCmd := exec.Command("docker", "exec", containerName, "bash", "-c", fmt.Sprintf(`
+		setupCmd := exec.Command("docker", "exec", env.ContainerName, "bash", "-c", fmt.Sprintf(`
 			# Ensure dokku user exists
 			id dokku || exit 1
 			
@@ -200,6 +318,19 @@ func setupSSH(t *testing.T, keys *testSSHKeys) {
 	// Give SSH service more time to fully start
 	time.Sleep(10 * time.Second)
 
+	// Test port connectivity
+	t.Logf("Testing port connectivity to localhost:%s", env.ExternalPorts["ssh"])
+	portCmd := exec.Command("nc", "-zv", "localhost", env.ExternalPorts["ssh"])
+	for i := 0; i < 5; i++ {
+		output, err := portCmd.CombinedOutput()
+		t.Logf("Port test attempt %d: %v, output: %s", i+1, err, string(output))
+		if err == nil {
+			t.Logf("Port %s is accessible", env.ExternalPorts["ssh"])
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+
 	// Verify SSH connectivity with the dokku version command
 	maxRetries := 5
 	retryDelay := 3 * time.Second
@@ -207,7 +338,7 @@ func setupSSH(t *testing.T, keys *testSSHKeys) {
 	for i := 0; i < maxRetries; i++ {
 		sshCmd := exec.Command("ssh", "-F", "/dev/null", // Bypass user SSH config
 			"-i", privateKeyPath,
-			"-p", sshPort,
+			"-p", env.ExternalPorts["ssh"],
 			"-o", "StrictHostKeyChecking=no",
 			"-o", "UserKnownHostsFile=/dev/null",
 			"-o", "ConnectTimeout=10",
@@ -232,9 +363,9 @@ func setupSSH(t *testing.T, keys *testSSHKeys) {
 	t.Logf("Warning: SSH connection test failed after %d attempts, but continuing anyway", maxRetries)
 }
 
-func isContainerReady(t *testing.T, keys *testSSHKeys) bool {
+func isContainerReady(t *testing.T, env *testEnvironment) bool {
 	// Check if we can SSH to the container and run a dokku command
-
+	keys := env.SSHKeys
 	keyFile := keys.privateKeyPath
 	if _, err := os.Stat(keyFile); os.IsNotExist(err) {
 		t.Logf("SSH key file not found at %s", keyFile)
@@ -247,6 +378,10 @@ func isContainerReady(t *testing.T, keys *testSSHKeys) bool {
 	// Get the Dokku version to use
 	dokkuVersion := getDokkuVersion()
 
+	// Determine connection details
+	sshHost := "localhost"
+	sshPort := env.ExternalPorts["ssh"]
+
 	// Try SSH connection with the key and test dokku command
 	cmd := exec.Command("ssh", "-F", "/dev/null",
 		"-o", "StrictHostKeyChecking=no",
@@ -255,7 +390,7 @@ func isContainerReady(t *testing.T, keys *testSSHKeys) bool {
 		"-o", "ConnectTimeout=10",
 		"-i", keyFile,
 		"-p", sshPort,
-		"dokku@localhost",
+		fmt.Sprintf("dokku@%s", sshHost),
 		"--quiet version")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -553,13 +688,20 @@ func destroyTerraform(t *testing.T, testDir string) {
 	terraform.Destroy(t, terraformOptions)
 }
 
-func cleanupDocker(t *testing.T) {
+func cleanupDocker(t *testing.T, env *testEnvironment) {
+	if env == nil || env.ContainerName == "" {
+		t.Logf("No container to clean up")
+		return
+	}
+
 	// Stop and remove container
-	docker.Stop(t, []string{containerName}, &docker.StopOptions{})
+	docker.Stop(t, []string{env.ContainerName}, &docker.StopOptions{})
 
 	// Remove container (don't remove the official image)
-	exec.Command("docker", "rm", "-f", containerName).Run()
+	exec.Command("docker", "rm", "-f", env.ContainerName).Run()
 	// Skip removing the official image: exec.Command("docker", "rmi", "-f", dokkuImageName).Run()
+
+	t.Logf("Cleaned up container: %s", env.ContainerName)
 }
 
 func cleanupTestFiles(t *testing.T, testDir string) {


### PR DESCRIPTION
# Changes
- feat(config): Introduce DokkuConfig for lazy SSH connections
- refactor(provider): Replace client usage with DokkuConfig in resources
- refactor(services): Update each service resource to use lazy connection
- refactor(tests): Modify test cases to accommodate new environment setup
- chore: Update example configurations to reflect changes in service initialization